### PR TITLE
Fixing Mirror Chamber logic and removing rooms in Camp and North Faron, which aren't needed

### DIFF
--- a/Generator/Assets/Entrances/EntranceTable.jsonc
+++ b/Generator/Assets/Entrances/EntranceTable.jsonc
@@ -154,7 +154,7 @@
         "Type": "Overworld",
         "SourceRoomSpawn":
         {
-            "SourceRoom": "North Faron Woods Near Lost Woods",
+            "SourceRoom": "North Faron Woods",
             "TargetRoom": "Lost Woods",
             "Stage": 54,
             "Room": 3,
@@ -166,7 +166,7 @@
         "TargetRoomSpawn":
         {
             "SourceRoom": "Lost Woods",
-            "TargetRoom": "North Faron Woods Near Lost Woods",
+            "TargetRoom": "North Faron Woods",
             "Stage": 45,
             "Room": 6,
             "Spawn": "03",
@@ -929,7 +929,7 @@
         "Type": "Overworld",
         "SourceRoomSpawn":
         {
-            "SourceRoom": "Bulblin Camp Back Exit",
+            "SourceRoom": "Bulblin Camp",
             "TargetRoom": "Outside Arbiters Grounds",
             "Stage": 55,
             "Room": 3,
@@ -941,7 +941,7 @@
         "TargetRoomSpawn":
         {
             "SourceRoom": "Outside Arbiters Grounds",
-            "TargetRoom": "Bulblin Camp Back Exit",
+            "TargetRoom": "Bulblin Camp",
             "Stage": 55,
             "Room": 1,
             "Spawn": "02",
@@ -2993,7 +2993,7 @@
         "Type": "Dungeon",
         "SourceRoomSpawn":
         {
-            "SourceRoom": "Mirror Chamber",
+            "SourceRoom": "Mirror Chamber Portal",
             "TargetRoom": "Palace of Twilight Entrance",
             "Stage": 15,
             "Room": 0,
@@ -3005,7 +3005,7 @@
         "TargetRoomSpawn":
         {
             "SourceRoom": "Palace of Twilight Entrance",
-            "TargetRoom": "Mirror Chamber",
+            "TargetRoom": "Mirror Chamber Upper",
             "Stage": 60,
             "Room": 4,
             "Spawn": "04",
@@ -3158,7 +3158,7 @@
         "SourceRoomSpawn":
         {
             "SourceRoom": "Arbiters Grounds Boss Room",
-            "TargetRoom": "Mirror Chamber",
+            "TargetRoom": "Mirror Chamber Lower",
             "Stage": 60,
             "Room": 4,
             "Spawn": "00",
@@ -3168,7 +3168,7 @@
         },
         "TargetRoomSpawn":
         {
-            "SourceRoom": "Mirror Chamber",
+            "SourceRoom": "Mirror Chamber Lower",
             "TargetRoom": "Arbiters Grounds Boss Room",
             "Stage": 25,
             "Room": 50,

--- a/Generator/Logic/LogicFunctions.cs
+++ b/Generator/Logic/LogicFunctions.cs
@@ -95,9 +95,6 @@ namespace TPRandomizer
                     "Mist Area Near North Faron Woods"
                 ].ReachedByPlaythrough
                 || Randomizer.Rooms.RoomDict["North Faron Woods"].ReachedByPlaythrough
-                || Randomizer.Rooms.RoomDict[
-                    "North Faron Woods Near Lost Woods"
-                ].ReachedByPlaythrough
                 || Randomizer.Rooms.RoomDict["Lost Woods"].ReachedByPlaythrough
                 || Randomizer.Rooms.RoomDict["Lost Woods Lower Battle Arena"].ReachedByPlaythrough
                 || Randomizer.Rooms.RoomDict["Lost Woods Upper Battle Arena"].ReachedByPlaythrough
@@ -170,8 +167,9 @@ namespace TPRandomizer
                     "Gerudo Desert Outside Bulblin Camp"
                 ].ReachedByPlaythrough
                 || Randomizer.Rooms.RoomDict["Bulblin Camp"].ReachedByPlaythrough
-                || Randomizer.Rooms.RoomDict["Bulblin Camp Back Exit"].ReachedByPlaythrough
-                || Randomizer.Rooms.RoomDict["Mirror Chamber"].ReachedByPlaythrough;
+                || Randomizer.Rooms.RoomDict["Mirror Chamber Lower"].ReachedByPlaythrough
+                || Randomizer.Rooms.RoomDict["Mirror Chamber Upper"].ReachedByPlaythrough
+                || Randomizer.Rooms.RoomDict["Mirror Chamber Portal"].ReachedByPlaythrough;
         }
 
         /// <summary>

--- a/Generator/World/Checks/Overworld/Lanayru Province/Outside South Castle Town Golden Wolf.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Outside South Castle Town Golden Wolf.jsonc
@@ -1,5 +1,5 @@
 {
-    "requirements": "Shadow_Crystal and Room.North_Faron_Woods_Near_Lost_Woods",
+    "requirements": "Shadow_Crystal and Room.North_Faron_Woods",
     "stageIDX": [57],
     "roomIDX": 16,
     "flag": "87",

--- a/Generator/World/Rooms/Dungeons/Arbiters Grounds.jsonc
+++ b/Generator/World/Rooms/Dungeons/Arbiters Grounds.jsonc
@@ -118,7 +118,7 @@
         "Exits": 
         [
           {
-            "ConnectedArea": "Mirror Chamber",
+            "ConnectedArea": "Mirror Chamber Lower",
             "Requirements": "CanDefeatStallord"
           }
         ],

--- a/Generator/World/Rooms/Dungeons/Palace of Twilight.jsonc
+++ b/Generator/World/Rooms/Dungeons/Palace of Twilight.jsonc
@@ -5,7 +5,7 @@
       "Exits": 
         [
           {
-            "ConnectedArea": "Mirror Chamber",
+            "ConnectedArea": "Mirror Chamber Upper",
             "Requirements": "true"
           },
           {

--- a/Generator/World/Rooms/Overworld/Faron Province/Faron Woods.jsonc
+++ b/Generator/World/Rooms/Overworld/Faron Province/Faron Woods.jsonc
@@ -19,7 +19,7 @@
         "ConnectedArea": "Faron Field",
         "Requirements": "canClearForest"
       },
-	  {
+      {
         "ConnectedArea": "Faron Woods Coros House Lower",
         "Requirements": "true"
       }
@@ -340,12 +340,12 @@
     "Exits":
     [
       {
-        "ConnectedArea": "North Faron Woods Near Lost Woods",
-        "Requirements": "Shadow_Crystal"
-      },
-      {
         "ConnectedArea": "Mist Area Near North Faron Woods",
         "Requirements": "true"
+      },
+      {
+        "ConnectedArea": "Lost Woods",
+        "Requirements": "Shadow_Crystal"
       },
       {
         "ConnectedArea": "Forest Temple Entrance",
@@ -356,23 +356,6 @@
         "North Faron Woods Deku Baba Chest",
         "Faron Woods Golden Wolf"
     ],
-    "Region": "Faron Woods"
-  },
-  {
-    "RoomName": "North Faron Woods Near Lost Woods",
-    "Exits":
-    [
-      {
-        "ConnectedArea": "Lost Woods",
-        "Requirements": "true"
-      },
-      // You can save warp to North Faron Woods
-      {
-        "ConnectedArea": "North Faron Woods",
-        "Requirements": "true"
-      }
-    ],
-    "Checks": [""],
     "Region": "Faron Woods"
   }
 ]

--- a/Generator/World/Rooms/Overworld/Faron Province/Sacred Grove.jsonc
+++ b/Generator/World/Rooms/Overworld/Faron Province/Sacred Grove.jsonc
@@ -12,8 +12,9 @@
         "Requirements": "(CanDefeatSkullKid and Shadow_Crystal) or (Setting.totEntrance equals Open) or (Setting.totEntrance equals OpenGrove)"
       },
       {
-        "ConnectedArea": "North Faron Woods Near Lost Woods",
+        "ConnectedArea": "North Faron Woods",
         "Requirements": "true"
+        // In North Faron Woods, when you are near the Lost Woods entrance, you can save-warp to the main part of North Faron Woods.
       }
     ],
     "Checks": 

--- a/Generator/World/Rooms/Overworld/Gerudo Desert/Gerudo Desert.jsonc
+++ b/Generator/World/Rooms/Overworld/Gerudo Desert/Gerudo Desert.jsonc
@@ -169,12 +169,12 @@
     "Exits":
     [
       {
-        "ConnectedArea": "Bulblin Camp Back Exit",
-        "Requirements": "((Gerudo_Desert_Bulblin_Camp_Key or (Setting.smallKeySettings equals Keysy)) and CanDefeatKingBulblinDesert) or (Setting.skipArbitersEntrance equals True)"
-      },
-      {
         "ConnectedArea": "Gerudo Desert Outside Bulblin Camp",
         "Requirements": "true"
+      },
+      {
+        "ConnectedArea": "Outside Arbiters Grounds",
+        "Requirements": "((Gerudo_Desert_Bulblin_Camp_Key or (Setting.smallKeySettings equals Keysy)) and CanDefeatKingBulblinDesert) or (Setting.skipArbitersEntrance equals True)"
       }
     ],
     "Checks":
@@ -188,27 +188,11 @@
     "Region": "Gerudo Desert"
   },
   {
-    "RoomName": "Bulblin Camp Back Exit",
-    "Exits":
-    [
-      {
-        "ConnectedArea": "Bulblin Camp",
-        "Requirements": "true"
-      },
-      {
-        "ConnectedArea": "Outside Arbiters Grounds",
-        "Requirements": "true"
-      }
-    ],
-    "Checks": [""],
-    "Region": "Gerudo Desert"
-  },
-  {
     "RoomName": "Outside Arbiters Grounds",
     "Exits":
     [
       {
-        "ConnectedArea": "Bulblin Camp Back Exit",
+        "ConnectedArea": "Bulblin Camp",
         "Requirements": "true"
       },
       {
@@ -224,7 +208,7 @@
     "Region": "Gerudo Desert"
   },
   {
-    "RoomName": "Mirror Chamber",
+    "RoomName": "Mirror Chamber Lower",
     "Exits":
     [
       {
@@ -232,8 +216,40 @@
         "Requirements": "true"
       },
       {
-        "ConnectedArea": "Palace of Twilight Entrance",
+        "ConnectedArea": "Mirror Chamber Upper",
+        "Requirements": "true"
+      }
+    ],
+    "Checks": [""],
+    "Region": "Gerudo Desert"
+  },
+  {
+    "RoomName": "Mirror Chamber Upper",
+    "Exits":
+    [
+      {
+        "ConnectedArea": "Mirror Chamber Lower",
+        "Requirements": "CanDefeatShadowBeast"
+      },
+      {
+        "ConnectedArea": "Mirror Chamber Portal",
         "Requirements": "CanDefeatShadowBeast and ((Setting.palaceRequirements equals Open) or ((Setting.palaceRequirements equals Fused_Shadows) and (Progressive_Fused_Shadow, 3)) or ((Setting.palaceRequirements equals Mirror_Shards) and (Progressive_Mirror_Shard, 3)) or ((Setting.palaceRequirements equals Vanilla) and canCompleteCityinTheSky))"
+      }
+    ],
+    "Checks": [""],
+    "Region": "Gerudo Desert"
+  },
+  {
+    "RoomName": "Mirror Chamber Portal",
+    "Exits":
+    [
+      {
+        "ConnectedArea": "Mirror Chamber Upper",
+        "Requirements": "CanDefeatShadowBeast"
+      },
+      {
+        "ConnectedArea": "Palace of Twilight Entrance",
+        "Requirements": "true"
       }
     ],
     "Checks": [""],


### PR DESCRIPTION
I split the Mirror Chamber into 3 rooms, as you would have to fight the shadow beasts, when you enter it from PoT, which wasn't included in the logic before.

Also I removed "Bulblin Camp Back Exit" and "North Faron Woods Near Lost Woods", as there is no need to have them.