### PR TITLE
Make beyondPoint hints respect same rules as Barren regarding itemAllowsBarrenForArea

### DIFF
--- a/Generator/Hints/HintGenerator.cs
+++ b/Generator/Hints/HintGenerator.cs
@@ -905,6 +905,7 @@ namespace TPRandomizer.Hints
                     .Category(beyondPointObj.category)
                     .ResolveToChecks();
 
+                AreaId areaId = AreaId.Zone(zone);
                 List<string> checksToHint = new();
                 bool hasImportantCheck = false;
                 foreach (string checkName in checkNames)
@@ -919,7 +920,7 @@ namespace TPRandomizer.Hints
                         Item contents = HintUtils.getCheckContents(checkName);
                         bool itemAllowsBarrenForArea = genData.ItemAllowsBarrenForArea(
                             contents,
-                            AreaId.Zone(zone)
+                            areaId
                         );
 
                         if (!itemAllowsBarrenForArea && genData.CheckIsGood(checkName))

--- a/Generator/Hints/HintGenerator.cs
+++ b/Generator/Hints/HintGenerator.cs
@@ -915,7 +915,14 @@ namespace TPRandomizer.Hints
                     )
                     {
                         checksToHint.Add(checkName);
-                        if (genData.CheckIsGood(checkName))
+
+                        Item contents = HintUtils.getCheckContents(checkName);
+                        bool itemAllowsBarrenForArea = genData.ItemAllowsBarrenForArea(
+                            contents,
+                            AreaId.Zone(zone)
+                        );
+
+                        if (!itemAllowsBarrenForArea && genData.CheckIsGood(checkName))
                         {
                             hasImportantCheck = true;
                             break;


### PR DESCRIPTION
- BeyondPoint signs in dungeons will follow the same rules as the BarrenHintCreator. If BigKeys are set to Own_Dungeon for example, then in the same way that this does not prevent the dungeon from being hinted barren, this also does not prevent a section of the dungeon from being hinted Barren by the BeyondPoint hint.