### PR TITLE
Update Kakariko Gorge Double Clawshot Chest.jsonc

### DIFF
--- a/Generator/Glitched-World/Checks/Overworld/Eldin Province/Kakariko Gorge Double Clawshot Chest.jsonc
+++ b/Generator/Glitched-World/Checks/Overworld/Eldin Province/Kakariko Gorge Double Clawshot Chest.jsonc
@@ -1,5 +1,5 @@
 {
-    "requirements": "(Progressive_Clawshot, 2) or HasSword or Shadow_Crystal",
+    "requirements": "(Progressive_Clawshot, 2) or CanDoLJA or Shadow_Crystal or (CanDoNicheStuff and HasSword)",
     "arcOffsets": ["16B8"],
     "stageIDX": [56],
     "roomIDX": 3,

--- a/Generator/Glitched-World/Checks/Overworld/Eldin Province/Kakariko Gorge Double Clawshot Chest.jsonc
+++ b/Generator/Glitched-World/Checks/Overworld/Eldin Province/Kakariko Gorge Double Clawshot Chest.jsonc
@@ -1,5 +1,5 @@
 {
-    "requirements": "(Progressive_Clawshot, 2) or CanDoLJA or Shadow_Crystal",
+    "requirements": "(Progressive_Clawshot, 2) or HasSword or Shadow_Crystal",
     "arcOffsets": ["16B8"],
     "stageIDX": [56],
     "roomIDX": 3,


### PR DESCRIPTION
https://www.zeldaspeedruns.com/tp/world/eldin-province#enemy-lja-to-gorge-hp-obsolete and/or https://youtu.be/tSeTqSXyXHk?t=10513

Both enemy LJA's allow for skipping use of the Gale Boomerang as part of CanLJA allowing for logic update to just need sword.