### PR TITLE
Update the hot spring water function

### DIFF
--- a/Generator/Logic/LogicFunctions.cs
+++ b/Generator/Logic/LogicFunctions.cs
@@ -174,7 +174,7 @@ namespace TPRandomizer
 
         /// <summary>
         /// summary text.
-        ///</summary>
+        /// </summary>
         public static bool canGetHotSpringWater()
         {
             return (
@@ -182,11 +182,6 @@ namespace TPRandomizer
                     || Randomizer.Rooms.RoomDict[
                         "Death Mountain Elevator Lower"
                     ].ReachedByPlaythrough
-                    || (
-                        Randomizer.Rooms.RoomDict["Kakariko Malo Mart"].ReachedByPlaythrough
-                        && Randomizer.Rooms.RoomDict["Lower Kakariko Village"].ReachedByPlaythrough
-                        && Randomizer.Rooms.RoomDict["Castle Town South"].ReachedByPlaythrough
-                    )
                 ) && HasBottle();
         }
 


### PR DESCRIPTION
When I just looked at the logic again, I realized that the springwater rush part is redundant. For the rush, you need access to "Lower Kakariko Village". But if you have access to that room and got a bottle, which you need anyways, the Elde Inn water becomes logically reachable automatically and there is then no need to require access to Malo Mart and CT South as well.