### PR TITLE
Disable broken sword code for minimal scarcity and required PoT

### DIFF
--- a/Generator/Assets/Items.cs
+++ b/Generator/Assets/Items.cs
@@ -947,15 +947,24 @@ namespace TPRandomizer
                         updateItemToCount(RandomizedImportantItems, kv.Key, kv.Value);
                     }
 
-                    // Reduce swords to 3 if barrenDungeons is on and Palace of
-                    // Twilight is not required.
-                    if (
-                        Randomizer.SSettings.barrenDungeons
-                        && (Randomizer.RequiredDungeons & 0x80) == 0
-                    )
-                    {
-                        updateItemToCount(RandomizedImportantItems, Item.Progressive_Sword, 3);
-                    }
+                    // TODO: RequiredDungeons not filled out at this point.
+                    // Disabling this as the low effort fix. To support removing
+                    // a sword when PoT is required, we would need to make sure
+                    // Randomizer.RequiredDungeons is available at this point.
+                    // Right now finding the required dungeons depends on
+                    // running a procedure which is dependent on the output of
+                    // this function (kind of a circular dependency), so a
+                    // different fix would be much higher effort.
+
+                    // // Reduce swords to 3 if barrenDungeons is on and Palace of
+                    // // Twilight is not required.
+                    // if (
+                    //     Randomizer.SSettings.barrenDungeons
+                    //     && (Randomizer.RequiredDungeons & 0x80) == 0
+                    // )
+                    // {
+                    //     updateItemToCount(RandomizedImportantItems, Item.Progressive_Sword, 3);
+                    // }
 
                     // Remove Magic Armor if Glitchless Logic
                     if (Randomizer.SSettings.logicRules == LogicRules.Glitchless)

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -277,7 +277,7 @@
                 <select
                   name=""
                   id="itemScarcityFieldset"
-                  data-tooltip-text="'Vanilla': No changes to the item pool.&#0010;&#0010;'Minimal': Removes unrequired items such as Heart Containers and Pieces, Hawkeye, etc. Has as few items as possible for Bomb Bags, Bows, Hidden Skills, Swords, and Wallets. No Magic Armor and 1 hidden skills if Glitchless logic.&#0010;&#0010;'Plentiful': One extra copy of major items. There are 17 Heart Containers but no Pieces of Heart. Extra keys if `Keysanity` or `Any Dungeon`."
+                  data-tooltip-text="'Vanilla': No changes to the item pool.&#0010;&#0010;'Minimal': Removes unrequired items such as Heart Containers and Pieces, Hawkeye, etc. Has as few items as possible for Bomb Bags, Bows, Hidden Skills, and Wallets. No Magic Armor and 1 Hidden Skill if Glitchless logic.&#0010;&#0010;'Plentiful': One extra copy of major items. There are 17 Heart Containers but no Pieces of Heart. Extra keys if `Keysanity` or `Any Dungeon`."
                 >
                   <option value="0">Vanilla</option>
                   <option value="1">Minimal</option>


### PR DESCRIPTION
- Always include 4 swords, even for minimal item scarcity.
- There is a circular dependency for knowing if PoT is required in order to reduce the number of swords, so for now we just leave swords at 4.