### PR TITLE
Update hasShield()

### DIFF
--- a/Generator/Logic/LogicFunctions.cs
+++ b/Generator/Logic/LogicFunctions.cs
@@ -1527,10 +1527,7 @@ namespace TPRandomizer
                 CanUse(Item.Hylian_Shield)
                 || Randomizer.Rooms.RoomDict["Kakariko Malo Mart"].ReachedByPlaythrough
                 || Randomizer.Rooms.RoomDict["Castle Town Goron House"].ReachedByPlaythrough
-                || (
-                    Randomizer.Rooms.RoomDict["Death Mountain Volcano"].ReachedByPlaythrough
-                    && CanDefeatGoron()
-                )
+                || Randomizer.Rooms.RoomDict("Death Mountain Elevator Lower"].ReachedByPlaythrough
             );
         }
 


### PR DESCRIPTION
The goron shop is part of the Elevator Lower room and has nothing to do with the Volcano room, so needing access to Volcano and the goron function is not correct actually.