### PR TITLE
Remove redundant bonk logic and Shadow Beast logic for the Icy Summit Poe

### DIFF
--- a/Generator/World/Checks/Overworld/Snowpeak Province/Snowpeak Icy Summit Poe.jsonc
+++ b/Generator/World/Checks/Overworld/Snowpeak Province/Snowpeak Icy Summit Poe.jsonc
@@ -1,5 +1,5 @@
 {
-    "requirements": "Shadow_Crystal and CanDefeatShadowBeast and ((Setting.bonksDoDamage equals False) or ((Setting.bonksDoDamage equals True) and ((Setting.damageMagnification not_equal OHKO) or CanUseBottledFairy)))",
+    "requirements": "Shadow_Crystal",
     "checkCategory": ["Overworld", "Poe", "Snowpeak Province"],
     "itemId": "Poe_Soul"
 }


### PR DESCRIPTION
When you enter Snowpeak Summit from SPR, you don't need the bonk logic and the Shadow Beast logic to get the poe check. When coming from Snowpeak Climb, it already requires them via room access.