### PR TITLE
Remove unnecessary logic requirement in Castle Town North

### DIFF
--- a/Generator/World/Rooms/Overworld/Lanayru Province/Castle Town.jsonc
+++ b/Generator/World/Rooms/Overworld/Lanayru Province/Castle Town.jsonc
@@ -205,9 +205,9 @@
     [
       {
         "ConnectedArea": "Castle Town North Behind First Door",
-        // Barrier is one-way. If coming from HC to Castle Town, you just have to be able to go through the doors. 
-        "Requirements": "CanCompleteMDH", 
-        "GlitchedRequirements": "CanCompleteMDH"
+        // Barrier is one-way.
+        "Requirements": "true", 
+        "GlitchedRequirements": "true"
       },
       {
         "ConnectedArea": "Hyrule Castle Entrance",


### PR DESCRIPTION
MDH only unlocks the southern huge door in that area. You don't need MDH to get to the area behind that door when coming from HC. This actually changes logic, as currently logic wants you to beat MDH to get the golden wolf check, even if you're coming from HC, which is not required in-game.