### PR TITLE
Add "Lower Hyrule Castle Chandelier" Option

### DIFF
--- a/Generator/Assets/Flags.cs
+++ b/Generator/Assets/Flags.cs
@@ -3,6 +3,14 @@ namespace TPRandomizer.Assets
     using System.Collections.Generic;
     using TPRandomizer.SSettings.Enums;
 
+    // Note on how the region flags are defined: The first number in the pair is
+    // the region node index (ex: Ordon is node 0, Hyrule Castle is node 0x18).
+    // The second number defines the offset and mask. The lower 3 bits (val % 8)
+    // says how much to right-shift a mask of 0x80 (shift 7 would give 0x01).
+    // The upper 5 bits say the offset within the region node. For example, 0x5A
+    // is 0b01011010 which is 01011 and 010. This means the offset is 0b01011
+    // (or 0xB) and the mask is 0x80 >> 2 (or 0x20).
+
     /// <summary>
     /// summary text.
     /// </summary>
@@ -393,6 +401,15 @@ namespace TPRandomizer.Assets
             { 0x15, 0xBF }, // statue placed in slot in room 1
         };
 
+        public static readonly byte[,] HcShortcutFlags = new byte[,]
+        {
+            { 0x18, 0x6F }, // watched double Dinalfos cs 1
+            { 0x18, 0x70 }, // watched double Dinalfos cs 2
+            { 0x18, 0x85 }, // watched focus on lowered chandelier cs
+            { 0x18, 0x9D }, // lower the main hall chandelier
+            { 0x18, 0xAF }, // defeated double Dinalfos (opens gates both sides)
+        };
+
         public static readonly byte[,] OpenMapRegionFlags = new byte[,]
         {
             // Lake Long Cave Flags
@@ -490,6 +507,7 @@ namespace TPRandomizer.Assets
                 { 19, OpenDMTRegionFlags },
                 { 20, OpenDotRegionFlags },
                 { 21, OpenMapRegionFlags },
+                { 22, HcShortcutFlags },
             };
 
         /// <summary>
@@ -701,6 +719,7 @@ namespace TPRandomizer.Assets
             /* 19 */RandomizerSettings.goronMinesEntrance == GoronMinesEntrance.Open,
             /* 20 */RandomizerSettings.openDot,
             /* 21 */RandomizerSettings.openMap,
+            /* 22 */RandomizerSettings.hcShortcut,
         };
     }
 }

--- a/Generator/Logic/SeedGenResults.cs
+++ b/Generator/Logic/SeedGenResults.cs
@@ -562,6 +562,7 @@ namespace TPRandomizer
             result.Add("hintDistribution", sSettings.hintDistribution.ToString());
             result.Add("randomizeStartingPoint", sSettings.randomizeStartingPoint);
             result.Add("shuffleRupees", sSettings.shuffleRupees);
+            result.Add("hcShortcut", sSettings.hcShortcut);
 
             result.Add("startingItems", sSettings.startingItems);
             result.Add("excludedChecks", sSettings.excludedChecks);

--- a/Generator/Logic/SharedSettings.cs
+++ b/Generator/Logic/SharedSettings.cs
@@ -58,6 +58,7 @@ namespace TPRandomizer
         public bool increaseSpinnerSpeed { get; set; }
         public bool openDot { get; set; }
         public bool noSmallKeysOnBosses { get; set; }
+        public bool hcShortcut { get; set; }
         public StartingToD startingToD { get; set; }
         public HintDistribution hintDistribution { get; set; }
         public bool randomizeStartingPoint { get; set; }
@@ -119,6 +120,7 @@ namespace TPRandomizer
             hintDistribution = (HintDistribution)processor.NextInt(5);
             randomizeStartingPoint = processor.NextBool();
             shuffleRupees = processor.NextBool();
+            hcShortcut = processor.NextBool();
             // We sort these lists so that the order which the UI happens to
             // pass the data up does not affect anything.
             startingItems = processor.NextItemList();

--- a/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Lantern Staircase Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Lantern Staircase Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "CanDefeatDarknut and Boomerang and CanDefeatBokoblin and  CanDefeatLizalfos and (Progressive_Clawshot, 2)",
-    "glitchedRequirements": "CanDefeatDarknut and Boomerang and CanDefeatBokoblin and  CanDefeatLizalfos and Progressive_Clawshot",
+    "requirements": "CanDefeatDarknut",
+    "glitchedRequirements": "CanDefeatDarknut",
     "checkCategory": ["Chest", "Dungeon", "Hyrule Castle"],
     "itemId": "Purple_Rupee"
 }

--- a/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Main Hall Northwest Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Main Hall Northwest Chest.jsonc
@@ -1,6 +1,14 @@
 {
-    "requirements": "canKnockDownHCPainting and CanDefeatLizalfos and CanDefeatDarknut and Boomerang and Lantern and (Progressive_Clawshot, 2)",
-    "glitchedRequirements": "(canKnockDownHCPainting and CanDefeatLizalfos and CanDefeatDarknut and Boomerang and Lantern and (Progressive_Clawshot, 1)) or (Progressive_Clawshot, 2)",
+    // Access is from the "Hyrule Castle After Double Darknuts" room since you
+    // must press the switch there to make the chest appear and Double-Darknut
+    // Skip is not infinitely reproducible. Note that the barrier fight is not
+    // relevant to this for multiple reasons, the simplest one being that the
+    // trigger for the fight is nowhere near anywhere you would walk to do this
+    // (but the fight is logically completed in order to get here regardless).
+    "requirements": "(Progressive_Clawshot, 2)",
+    // For glitched, you can easily clawshot to this chest from next to the
+    // center north door of the main hall, or you can LJA to it from the switch.
+    "glitchedRequirements": "(Progressive_Clawshot, 1) or CanDoLJA",
     "checkCategory": ["Chest", "Dungeon", "Hyrule Castle"],
     "itemId": "Silver_Rupee"
 }

--- a/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Main Hall Southwest Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Main Hall Southwest Chest.jsonc
@@ -1,6 +1,11 @@
 {
-    "requirements": "canKnockDownHCPainting and CanDefeatLizalfos and CanDefeatDarknut and Boomerang and Lantern and (Progressive_Clawshot, 2)",
-    "glitchedRequirements": "(canKnockDownHCPainting and CanDefeatLizalfos and CanDefeatDarknut and Boomerang and Lantern and (Progressive_Clawshot, 1)) or (Progressive_Clawshot, 2)",
+    // Access is from the "Hyrule Castle After Double Darknuts" room. Note that
+    // the Double-Darknut Skip is not infinitely reproducible since it is only
+    // available until you lower the shortcut chandelier, so there is no logical
+    // way even in glitched to get this chest without going through the Double
+    // Darknuts, at which point you just walk up and get it for free.
+    "requirements": "true",
+    "glitchedRequirements": "true",
     "checkCategory": ["Chest", "Dungeon", "Hyrule Castle"],
-    "itemId": "Orange_Rupee"
+    "itemId": "Purple_Rupee"
 }

--- a/Generator/World/Rooms/Dungeons/Hyrule Castle.jsonc
+++ b/Generator/World/Rooms/Dungeons/Hyrule Castle.jsonc
@@ -1,60 +1,53 @@
 [
-    { 
+    {
         "RoomName": "Ganondorf Castle",
-        "Exits": 
-        [
+        "Exits": [
             {
                 "ConnectedArea": "Hyrule Castle Tower Climb",
                 "Requirements": "true",
                 "GlitchedRequirements": "true"
             }
         ],
-        "Checks": 
-        [
-            "Hyrule Castle Ganondorf"
-        ], 
+        "Checks": ["Hyrule Castle Ganondorf"],
         "Region": "Ganondorf"
     },
     {
         "RoomName": "Hyrule Castle Entrance",
-        "Exits": 
-          [
+        "Exits": [
             {
-              "ConnectedArea": "Castle Town North Inside Barrier",
-              "Requirements": "true",
-              "GlitchedRequirements": "true"
+                "ConnectedArea": "Castle Town North Inside Barrier",
+                "Requirements": "true",
+                "GlitchedRequirements": "true"
             },
             {
-              "ConnectedArea": "Hyrule Castle Main Hall",
-              "Requirements": "(Hyrule_Castle_Small_Key, 1)",
-              "GlitchedRequirements": "(Hyrule_Castle_Small_Key, 1)"
+                "ConnectedArea": "Hyrule Castle Main Hall",
+                "Requirements": "(Hyrule_Castle_Small_Key, 1)",
+                "GlitchedRequirements": "(Hyrule_Castle_Small_Key, 1)"
             },
             {
-              "ConnectedArea": "Hyrule Castle Outside West Wing",
-              "Requirements": "CanDefeatBokoblinRed",
-              "GlitchedRequirements": "CanDefeatBokoblinRed"
+                "ConnectedArea": "Hyrule Castle Outside West Wing",
+                "Requirements": "CanDefeatBokoblinRed",
+                "GlitchedRequirements": "CanDefeatBokoblinRed"
             },
             {
-              "ConnectedArea": "Hyrule Castle Outside East Wing",
-              "Requirements": "CanDefeatBokoblinRed",
-              "GlitchedRequirements": "CanDefeatBokoblinRed"
+                "ConnectedArea": "Hyrule Castle Outside East Wing",
+                "Requirements": "CanDefeatBokoblinRed",
+                "GlitchedRequirements": "CanDefeatBokoblinRed"
             }
-          ],
-          "Checks": [""],
-          "Region": "Hyrule Castle"
-    },
-    { 
-        "RoomName": "Hyrule Castle Graveyard",
-        "Exits": 
-        [
-        {
-            "ConnectedArea": "Hyrule Castle Outside East Wing",
-            "Requirements": "Shadow_Crystal",
-            "GlitchedRequirements": "Shadow_Crystal"
-        }
         ],
-        "Checks": 
-        [
+        "Checks": [""],
+        "Region": "Hyrule Castle"
+    },
+    {
+        "RoomName": "Hyrule Castle Graveyard",
+        "Exits": [
+            {
+                "ConnectedArea": "Hyrule Castle Outside East Wing",
+                "Requirements": "Shadow_Crystal",
+                "GlitchedRequirements": "Shadow_Crystal"
+            }
+        ],
+        "Checks": [
             "Hyrule Castle Graveyard Grave Switch Room Right Chest",
             "Hyrule Castle Graveyard Grave Switch Room Front Left Chest",
             "Hyrule Castle Graveyard Grave Switch Room Back Left Chest",
@@ -62,133 +55,153 @@
         ],
         "Region": "Hyrule Castle"
     },
-    { 
-        "RoomName": "Hyrule Castle Inside East Wing",
-        "Exits": 
-        [
-        {
-            "ConnectedArea": "Hyrule Castle Main Hall",
-            "Requirements": "true",
-            "GlitchedRequirements": "true"
-        },
-        {
-            "ConnectedArea": "Hyrule Castle Third Floor Balcony",
-            "Requirements": "Lantern and CanDefeatDinalfos",
-            "GlitchedRequirements": "Lantern and CanDefeatDinalfos"
-        }
+    {
+        "RoomName": "Hyrule Castle Main Hall",
+        "Exits": [
+            {
+                "ConnectedArea": "Hyrule Castle Entrance",
+                "Requirements": "true",
+                "GlitchedRequirements": "true"
+            },
+            {
+                "ConnectedArea": "Hyrule Castle Above Lantern Staircase",
+                "Requirements": "CanDefeatBokoblin and CanDefeatLizalfos and (Progressive_Clawshot, 2) and CanDefeatDarknut and Boomerang",
+                "GlitchedRequirements": "CanDefeatBokoblin and CanDefeatLizalfos and Progressive_Clawshot and CanDefeatDarknut and Boomerang"
+            },
+            {
+                "ConnectedArea": "Hyrule Castle After Double Dinalfos",
+                "Requirements": "CanDefeatBokoblin and CanDefeatLizalfos and (Setting.hcShortcut equals True) and (Progressive_Clawshot, 2)",
+                "GlitchedRequirements": "CanDefeatBokoblin and CanDefeatLizalfos and (Setting.hcShortcut equals True) and (Progressive_Clawshot, 2)"
+            }
         ],
-        "Checks": [""], 
-        "Region": "Hyrule Castle"
-    },
-    { 
-        "RoomName": "Hyrule Castle Inside West Wing",
-        "Exits": 
-        [
-        {
-            "ConnectedArea": "Hyrule Castle Main Hall",
-            "Requirements": "true",
-            "GlitchedRequirements": "true"
-        },
-        {
-            "ConnectedArea": "Hyrule Castle Third Floor Balcony",
-            "Requirements": "canKnockDownHCPainting and CanDefeatLizalfos and CanDefeatDarknut",
-            "GlitchedRequirements": "canKnockDownHCPainting and CanDefeatLizalfos and CanDefeatDarknut"
-        }
-        ],
-        "Checks": [""], 
+        "Checks": ["Hyrule Castle Main Hall Northeast Chest"],
         "Region": "Hyrule Castle"
     },
     {
-        "RoomName": "Hyrule Castle Main Hall",
-        "Exits": 
-        [
-          {
-            "ConnectedArea": "Hyrule Castle Entrance",
-            "Requirements": "true",
-            "GlitchedRequirements": "true"
-          },
-          {
-            "ConnectedArea": "Hyrule Castle Inside East Wing",
-            "Requirements": "CanDefeatBokoblin and  CanDefeatLizalfos and (Progressive_Clawshot, 2) and CanDefeatDarknut and Boomerang",
-            "GlitchedRequirements": "CanDefeatBokoblin and CanDefeatLizalfos and Progressive_Clawshot and CanDefeatDarknut and Boomerang"
-          },
-          {
-            "ConnectedArea": "Hyrule Castle Inside West Wing",
-            "Requirements": "CanDefeatBokoblin and  CanDefeatLizalfos and (Progressive_Clawshot, 2) and CanDefeatDarknut and Boomerang",
-            "GlitchedRequirements": "CanDefeatBokoblin and CanDefeatLizalfos and Progressive_Clawshot and CanDefeatDarknut and Boomerang"
-          }
-        ],
-        "Checks":
-        [
-            "Hyrule Castle Main Hall Northeast Chest",
-            "Hyrule Castle Main Hall Southwest Chest",
-            "Hyrule Castle Main Hall Northwest Chest",
-            "Hyrule Castle Lantern Staircase Chest"
-         ],
-        "Region": "Hyrule Castle"
-    },
-    { 
         "RoomName": "Hyrule Castle Outside East Wing",
-        "Exits": 
-        [
-        {
-            "ConnectedArea": "Hyrule Castle Entrance",
-            "Requirements": "true",
-            "GlitchedRequirements": "true"
-        },
-        {
-            "ConnectedArea": "Hyrule Castle Graveyard",
-            "Requirements": "Shadow_Crystal",
-            "GlitchedRequirements": "Shadow_Crystal"
-        }
+        "Exits": [
+            {
+                "ConnectedArea": "Hyrule Castle Entrance",
+                "Requirements": "true",
+                "GlitchedRequirements": "true"
+            },
+            {
+                "ConnectedArea": "Hyrule Castle Graveyard",
+                "Requirements": "Shadow_Crystal",
+                "GlitchedRequirements": "Shadow_Crystal"
+            }
         ],
-        "Checks": 
-        [
+        "Checks": [
             "Hyrule Castle East Wing Boomerang Puzzle Chest",
             "Hyrule Castle East Wing Balcony Chest"
         ],
         "Region": "Hyrule Castle"
     },
-    { 
+    {
         "RoomName": "Hyrule Castle Outside West Wing",
-        "Exits": 
-        [
-        {
-            "ConnectedArea": "Hyrule Castle Entrance",
-            "Requirements": "true",
-            "GlitchedRequirements": "true"
-        }
+        "Exits": [
+            {
+                "ConnectedArea": "Hyrule Castle Entrance",
+                "Requirements": "true",
+                "GlitchedRequirements": "true"
+            }
         ],
-        "Checks": 
-        [
+        "Checks": [
             "Hyrule Castle West Courtyard North Small Chest",
             "Hyrule Castle West Courtyard Central Small Chest",
             "Hyrule Castle King Bulblin Key"
         ],
         "Region": "Hyrule Castle"
     },
-    { 
-        "RoomName": "Hyrule Castle Third Floor Balcony",
-        "Exits": 
-        [
-        {
-            "ConnectedArea": "Hyrule Castle Inside West Wing",
-            "Requirements": "CanDefeatDarknut and CanDefeatLizalfos and canKnockDownHCPainting",
-            "GlitchedRequirements": "CanDefeatDarknut and CanDefeatLizalfos and canKnockDownHCPainting"
-        },
-        {
-            "ConnectedArea": "Hyrule Castle Inside East Wing",
-            "Requirements": "Lantern and CanDefeatDinalfos",
-            "GlitchedRequirements": "Lantern and CanDefeatDinalfos"
-        },
-        {
-            "ConnectedArea": "Hyrule Castle Tower Climb",
-            "Requirements": "(Hyrule_Castle_Small_Key, 2)",
-            "GlitchedRequirements": "(Hyrule_Castle_Small_Key, 2)"
-        }
+    {
+        "RoomName": "Hyrule Castle Above Lantern Staircase",
+        "Exits": [
+            {
+                "ConnectedArea": "Hyrule Castle Main Hall",
+                "Requirements": "CanDefeatDarknut",
+                "GlitchedRequirements": "CanDefeatDarknut"
+            },
+            {
+                "ConnectedArea": "Hyrule Castle After Double Dinalfos",
+                "Requirements": "Lantern and CanDefeatDinalfos",
+                "GlitchedRequirements": "Lantern and CanDefeatDinalfos"
+            },
+            {
+                "ConnectedArea": "Hyrule Castle After Double Darknuts",
+                "Requirements": "canKnockDownHCPainting and CanDefeatLizalfos and CanDefeatDarknut",
+                "GlitchedRequirements": "canKnockDownHCPainting and CanDefeatLizalfos and CanDefeatDarknut"
+            }
         ],
-        "Checks": 
-        [
+        "Checks": ["Hyrule Castle Lantern Staircase Chest"],
+        "Region": "Hyrule Castle"
+    },
+    {
+        "RoomName": "Hyrule Castle After Double Dinalfos",
+        "Exits": [
+            {
+                "ConnectedArea": "Hyrule Castle Main Hall",
+                "Requirements": "true",
+                "GlitchedRequirements": "true"
+            },
+            {
+                "ConnectedArea": "Hyrule Castle Above Lantern Staircase",
+                "Requirements": "true",
+                "GlitchedRequirements": "true"
+            },
+            {
+                "ConnectedArea": "Hyrule Castle Third Floor Balcony",
+                "Requirements": "true",
+                "GlitchedRequirements": "true"
+            }
+        ],
+        "Checks": [""],
+        "Region": "Hyrule Castle"
+    },
+    {
+        "RoomName": "Hyrule Castle After Double Darknuts",
+        "Exits": [
+            {
+                "ConnectedArea": "Hyrule Castle Main Hall",
+                "Requirements": "true",
+                "GlitchedRequirements": "true"
+            },
+            {
+                "ConnectedArea": "Hyrule Castle Above Lantern Staircase",
+                "Requirements": "true",
+                "GlitchedRequirements": "true"
+            },
+            {
+                "ConnectedArea": "Hyrule Castle Third Floor Balcony",
+                "Requirements": "true",
+                "GlitchedRequirements": "true"
+            }
+        ],
+        "Checks": [
+            "Hyrule Castle Main Hall Southwest Chest",
+            "Hyrule Castle Main Hall Northwest Chest"
+        ],
+        "Region": "Hyrule Castle"
+    },
+    {
+        "RoomName": "Hyrule Castle Third Floor Balcony",
+        "Exits": [
+            {
+                "ConnectedArea": "Hyrule Castle After Double Dinalfos",
+                "Requirements": "(Lantern and CanDefeatDinalfos) or (Setting.hcShortcut equals True)",
+                "GlitchedRequirements": "(Lantern and CanDefeatDinalfos) or (Setting.hcShortcut equals True)"
+            },
+            {
+                "ConnectedArea": "Hyrule Castle After Double Darknuts",
+                "Requirements": "CanDefeatDarknut and CanDefeatLizalfos and canKnockDownHCPainting",
+                "GlitchedRequirements": "CanDefeatDarknut and CanDefeatLizalfos and canKnockDownHCPainting"
+            },
+            {
+                "ConnectedArea": "Hyrule Castle Tower Climb",
+                "Requirements": "(Hyrule_Castle_Small_Key, 2)",
+                "GlitchedRequirements": "(Hyrule_Castle_Small_Key, 2)"
+            }
+        ],
+        "Checks": [
             "Hyrule Castle Southeast Balcony Tower Chest",
             "Hyrule Castle Big Key Chest"
         ],
@@ -196,39 +209,36 @@
     },
     {
         "RoomName": "Hyrule Castle Tower Climb",
-        "Exits": 
-          [
+        "Exits": [
             {
-              "ConnectedArea": "Hyrule Castle Third Floor Balcony",
-              "Requirements": "true",
-              "GlitchedRequirements": "true"
+                "ConnectedArea": "Hyrule Castle Third Floor Balcony",
+                "Requirements": "true",
+                "GlitchedRequirements": "true"
             },
             {
-              "ConnectedArea": "Hyrule Castle Treasure Room",
-              "Requirements": "(Hyrule_Castle_Small_Key, 3) and Spinner and (Progressive_Clawshot, 2) and CanDefeatDarknut and CanDefeatLizalfos",
-              "GlitchedRequirements": "(Hyrule_Castle_Small_Key, 3) and (Spinner or CanDoJSLJA) and Progressive_Clawshot and CanDefeatDarknut and CanDefeatLizalfos"
+                "ConnectedArea": "Hyrule Castle Treasure Room",
+                "Requirements": "(Hyrule_Castle_Small_Key, 3) and Spinner and (Progressive_Clawshot, 2) and CanDefeatDarknut and CanDefeatLizalfos",
+                "GlitchedRequirements": "(Hyrule_Castle_Small_Key, 3) and (Spinner or CanDoJSLJA) and Progressive_Clawshot and CanDefeatDarknut and CanDefeatLizalfos"
             },
             {
-              "ConnectedArea": "Ganondorf Castle",
-              "Requirements": "Spinner and (Progressive_Clawshot, 2) and CanDefeatDarknut and CanDefeatLizalfos and Hyrule_Castle_Big_Key",
-              "GlitchedRequirements": "(Spinner or CanDoJSLJA) and Progressive_Clawshot and CanDefeatDarknut and CanDefeatLizalfos and Hyrule_Castle_Big_Key"
+                "ConnectedArea": "Ganondorf Castle",
+                "Requirements": "Spinner and (Progressive_Clawshot, 2) and CanDefeatDarknut and CanDefeatLizalfos and Hyrule_Castle_Big_Key",
+                "GlitchedRequirements": "(Spinner or CanDoJSLJA) and Progressive_Clawshot and CanDefeatDarknut and CanDefeatLizalfos and Hyrule_Castle_Big_Key"
             }
-          ],
-          "Checks": [""],
-          "Region": "Hyrule Castle"
-    },
-    { 
-        "RoomName": "Hyrule Castle Treasure Room",
-        "Exits": 
-        [
-        {
-            "ConnectedArea": "Hyrule Castle Tower Climb",
-            "Requirements": "true",
-            "GlitchedRequirements": "true"
-        }
         ],
-        "Checks": 
-        [
+        "Checks": [""],
+        "Region": "Hyrule Castle"
+    },
+    {
+        "RoomName": "Hyrule Castle Treasure Room",
+        "Exits": [
+            {
+                "ConnectedArea": "Hyrule Castle Tower Climb",
+                "Requirements": "true",
+                "GlitchedRequirements": "true"
+            }
+        ],
+        "Checks": [
             "Hyrule Castle Treasure Room Eighth Small Chest",
             "Hyrule Castle Treasure Room Seventh Small Chest",
             "Hyrule Castle Treasure Room Sixth Small Chest",

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -568,6 +568,20 @@
                 />
                 <label for="openDotCheckbox"> Open Door of Time </label><br />
               </div>
+              <div
+                style="width: 90%"
+                data-tooltip-text="If enabled, the shortcut chandelier in the Hyrule Castle main hall will be lowered, and the double Dinalfos room will be cleared.&#0010;&#0010;This allows for you to continue from the main hall to the southern balcony more quickly and with fewer item requirements (ex: no Gale Boomerang)."
+              >
+                <input
+                  type="checkbox"
+                  id="hcShortcutCheckbox"
+                  name="Lower Hyrule Castle Chandelier"
+                  value=""
+                />
+                <label for="hcShortcutCheckbox"
+                  >Lower Hyrule Castle Chandelier</label
+                ><br />
+              </div>
             </fieldset>
           </div>
           <div class="tabColumn">
@@ -634,7 +648,9 @@
                   name="Randomize Starting Point Checkbox"
                   value=""
                 />
-                <label for="randomizeStartingPointCheckbox">Randomize Starting Location</label><br />
+                <label for="randomizeStartingPointCheckbox"
+                  >Randomize Starting Location</label
+                ><br />
               </div>
               <div class="selectGroup" style="margin-top: 8px">
                 <label for="trapItemFieldset">Trap Item Frequency</label><br />
@@ -791,7 +807,8 @@
                 data-tooltip-text="Sets the minimum progressive sword level that is required to strike the pedestal in Sacred Grove and the Temple of Time. This means that if set to Ordon Sword, the pedestal can be struck with the Ordon, Master, or Light Sword, but not the Wooden Sword. If set to 'none', the player does not need to strike the sword into the pedestal.&#0010;"
                 data-tooltip-position="left"
               >
-                <label for="totEntranceFieldset">Temple of Time Sword Requirement</label
+                <label for="totEntranceFieldset"
+                  >Temple of Time Sword Requirement</label
                 ><br />
                 <select name="Temple of Time Entrance" id="totEntranceFieldset">
                   <option value="0">None</option>

--- a/packages/client/js/shared.js
+++ b/packages/client/js/shared.js
@@ -443,6 +443,7 @@
       { id: 'hintDistributionFieldset', bitLength: 5 },
       { id: 'randomizeStartingPointCheckbox' },
       { id: 'rupeeCheckbox' },
+      { id: 'hcShortcutCheckbox' },
     ].map(({ id, bitLength }) => {
       const val = getVal(id);
       if (bitLength) {
@@ -916,9 +917,11 @@
     if (version >= 6) {
       processBasic({ id: 'randomizeStartingPoint' });
       processBasic({ id: 'rupees' });
+      processBasic({ id: 'hcShortcut' });
     } else {
       res.randomizeStartingPoint = false; // Vanilla
       res.rupees = false; // Vanilla
+      res.hcShortcut = false;
     }
 
     res.startingItems = processor.nextEolList(9);

--- a/packages/client/script.js
+++ b/packages/client/script.js
@@ -314,6 +314,9 @@ document
 document
   .getElementById('rupeeCheckbox')
   .addEventListener('click', setSettingsString);
+document
+  .getElementById('hcShortcutCheckbox')
+  .addEventListener('click', setSettingsString);
 document.getElementById('itemScarcityFieldset').onchange = setSettingsString;
 document.getElementById('damageMagFieldset').onchange = setSettingsString;
 document.getElementById('todFieldset').onchange = setSettingsString;
@@ -1244,8 +1247,12 @@ function populateSSettings(s) {
   $('#noSmallKeysOnBossesCheckbox').prop('checked', s.noSmallKeysOnBosses);
   $('#todFieldset').val(s.startingToD);
   $('#hintDistributionFieldset').val(s.hintDistribution);
-  $('#randomizeStartingPointCheckbox').prop('checked', s.randomizeStartingPoint);
+  $('#randomizeStartingPointCheckbox').prop(
+    'checked',
+    s.randomizeStartingPoint
+  );
   $('#rupeeCheckbox').prop('checked', s.rupees);
+  $('#hcShortcutCheckbox').prop('checked', s.hcShortcut);
 
   const $excludedChecksParent = $('#baseExcludedChecksListbox');
   s.excludedChecks.forEach((checkNumId) => {


### PR DESCRIPTION
- This will lower the chandelier in the main hall, allowing you to go to Ganondorf more quickly, and without necessarily needing boomerang, etc.
- Fix "Hyrule Castle Main Hall Southwest Chest" vanilla item to be a purple Rupee
- Update part of the HC room graph to account for the new logic, and move a lot of the repeated logic to the room connections rather than repeating on every check. Most of the file diff is from formatting