### PR TITLE
Fix capitlization on `can___` and `has___` logic function names.

### DIFF
--- a/Generator/Logic/LogicFunctions.cs
+++ b/Generator/Logic/LogicFunctions.cs
@@ -124,7 +124,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canGetHotSpringWater()
+        public static bool CanGetHotSpringWater()
         {
             return (
                     Randomizer.Rooms.RoomDict["Lower Kakariko Village"].ReachedByPlaythrough
@@ -979,7 +979,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanDefeatStalfos()
         {
-            return (canSmash());
+            return (CanSmash());
         }
 
         /// <summary>
@@ -1319,7 +1319,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanDefeatDiababa()
         {
-            return canLaunchBombs()
+            return CanLaunchBombs()
                 || (
                     CanUse(Item.Boomerang)
                     && (
@@ -1439,7 +1439,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canSmash()
+        public static bool CanSmash()
         {
             return (CanUse(Item.Ball_and_Chain) || hasBombs());
         }
@@ -1447,7 +1447,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canBurnWebs()
+        public static bool CanBurnWebs()
         {
             return CanUse(Item.Lantern) || hasBombs() || CanUse(Item.Ball_and_Chain);
         }
@@ -1503,7 +1503,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canLaunchBombs()
+        public static bool CanLaunchBombs()
         {
             return ((CanUse(Item.Boomerang) || CanUse(Item.Progressive_Bow)) && hasBombs());
         }
@@ -1511,7 +1511,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canCutHangingWeb()
+        public static bool CanCutHangingWeb()
         {
             return (
                 CanUse(Item.Progressive_Clawshot)
@@ -1534,7 +1534,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canKnockDownHCPainting()
+        public static bool CanKnockDownHCPainting()
         {
             return (
                 CanUse(Item.Progressive_Bow)
@@ -1555,7 +1555,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canBreakMonkeyCage()
+        public static bool CanBreakMonkeyCage()
         {
             return (
                 HasSword()
@@ -1577,7 +1577,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canPressMinesSwitch()
+        public static bool CanPressMinesSwitch()
         {
             return CanUse(Item.Iron_Boots) || (CanDoNicheStuff() && CanUse(Item.Ball_and_Chain));
         }
@@ -1585,10 +1585,10 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canFreeAllMonkeys()
+        public static bool CanFreeAllMonkeys()
         {
             return (
-                canBreakMonkeyCage()
+                CanBreakMonkeyCage()
                 && (
                     CanUse(Item.Lantern)
                     || (
@@ -1596,7 +1596,7 @@ namespace TPRandomizer
                         && (hasBombs() || CanUse(Item.Iron_Boots))
                     )
                 )
-                && canBurnWebs()
+                && CanBurnWebs()
                 && CanUse(Item.Boomerang)
                 && CanDefeatBokoblin()
                 && (
@@ -1609,7 +1609,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canKnockDownHangingBaba()
+        public static bool CanKnockDownHangingBaba()
         {
             return (
                 CanUse(Item.Progressive_Bow)
@@ -1622,10 +1622,10 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canBreakWoodenDoor()
+        public static bool CanBreakWoodenDoor()
         {
             return (
-                CanUse(Item.Shadow_Crystal) || HasSword() || canSmash() || CanUseBacksliceAsSword()
+                CanUse(Item.Shadow_Crystal) || HasSword() || CanSmash() || CanUseBacksliceAsSword()
             );
         }
 
@@ -1684,7 +1684,7 @@ namespace TPRandomizer
             return (
                 Randomizer.Rooms.RoomDict["Lost Woods"].ReachedByPlaythrough
                 || (
-                    canCompleteGoronMines()
+                    CanCompleteGoronMines()
                     && Randomizer.Rooms.RoomDict["Kakariko Malo Mart"].ReachedByPlaythrough
                 )
                 || (
@@ -1703,11 +1703,11 @@ namespace TPRandomizer
                 || Randomizer.Rooms.RoomDict["Arbiters Grounds Entrance"].ReachedByPlaythrough
                 || (
                     Randomizer.Rooms.RoomDict["Lake Hylia Long Cave"].ReachedByPlaythrough
-                    && canSmash()
+                    && CanSmash()
                 )
                 || Randomizer.Rooms.RoomDict["Ordon Seras Shop"].ReachedByPlaythrough
                 || (
-                    canCompleteGoronMines()
+                    CanCompleteGoronMines()
                     && Randomizer.Rooms.RoomDict["Lower Kakariko Village"].ReachedByPlaythrough
                     && CanChangeTime()
                 )
@@ -1721,7 +1721,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canCompletePrologue()
+        public static bool CanCompletePrologue()
         {
             return (
                 (
@@ -1735,7 +1735,7 @@ namespace TPRandomizer
         {
             return (
                 Randomizer.Rooms.RoomDict["Ordon Ranch"].ReachedByPlaythrough
-                || canCompletePrologue()
+                || CanCompletePrologue()
             );
         }
 
@@ -1747,11 +1747,11 @@ namespace TPRandomizer
             return (
                 (Randomizer.SSettings.skipMdh == true)
                 || (
-                    canCompleteLakebedTemple()
+                    CanCompleteLakebedTemple()
                     && Randomizer.Rooms.RoomDict["Castle Town South"].ReachedByPlaythrough
                 )
             );
-            //return (canCompleteLakebedTemple() || (Randomizer.SSettings.skipMdh == true));
+            //return (CanCompleteLakebedTemple() || (Randomizer.SSettings.skipMdh == true));
         }
 
         public static bool CanMidnaCharge()
@@ -1767,14 +1767,14 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canClearForest()
+        public static bool CanClearForest()
         {
             return (
                 (
-                    canCompleteForestTemple()
+                    CanCompleteForestTemple()
                     || (Randomizer.SSettings.faronWoodsLogic == FaronWoodsLogic.Open)
                 )
-                && canCompletePrologue()
+                && CanCompletePrologue()
                 && CanCompleteFaronTwilight()
             );
         }
@@ -1786,7 +1786,7 @@ namespace TPRandomizer
         {
             return Randomizer.SSettings.faronTwilightCleared
                 || (
-                    canCompletePrologue()
+                    CanCompletePrologue()
                     && Randomizer.Rooms.RoomDict["South Faron Woods"].ReachedByPlaythrough
                     && Randomizer.Rooms.RoomDict[
                         "Faron Woods Coros House Lower"
@@ -1899,7 +1899,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canCompleteForestTemple()
+        public static bool CanCompleteForestTemple()
         {
             return CanUse(Item.Diababa_Defeated);
         }
@@ -1907,7 +1907,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canCompleteGoronMines()
+        public static bool CanCompleteGoronMines()
         {
             return CanUse(Item.Fyrus_Defeated);
         }
@@ -1915,7 +1915,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canCompleteLakebedTemple()
+        public static bool CanCompleteLakebedTemple()
         {
             return CanUse(Item.Morpheel_Defeated);
         }
@@ -1923,7 +1923,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canCompleteArbitersGrounds()
+        public static bool CanCompleteArbitersGrounds()
         {
             return CanUse(Item.Stallord_Defeated);
         }
@@ -1931,7 +1931,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canCompleteSnowpeakRuins()
+        public static bool CanCompleteSnowpeakRuins()
         {
             return CanUse(Item.Blizzeta_Defeated);
         }
@@ -1939,7 +1939,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canCompleteTempleofTime()
+        public static bool CanCompleteTempleofTime()
         {
             return CanUse(Item.Armogohma_Defeated);
         }
@@ -1947,7 +1947,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canCompleteCityinTheSky()
+        public static bool CanCompleteCityinTheSky()
         {
             return CanUse(Item.Argorok_Defeated);
         }
@@ -1955,7 +1955,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canCompletePalaceofTwilight()
+        public static bool CanCompletePalaceofTwilight()
         {
             return CanUse(Item.Zant_Defeated);
         }
@@ -1963,17 +1963,17 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool canCompleteAllDungeons()
+        public static bool CanCompleteAllDungeons()
         {
             return (
-                canCompleteForestTemple()
-                && canCompleteGoronMines()
-                && canCompleteLakebedTemple()
-                && canCompleteArbitersGrounds()
-                && canCompleteSnowpeakRuins()
-                && canCompleteTempleofTime()
-                && canCompleteCityinTheSky()
-                && canCompletePalaceofTwilight()
+                CanCompleteForestTemple()
+                && CanCompleteGoronMines()
+                && CanCompleteLakebedTemple()
+                && CanCompleteArbitersGrounds()
+                && CanCompleteSnowpeakRuins()
+                && CanCompleteTempleofTime()
+                && CanCompleteCityinTheSky()
+                && CanCompletePalaceofTwilight()
             );
         }
 
@@ -2333,13 +2333,13 @@ namespace TPRandomizer
             return hasBombs() || CanDoBSMoonBoots() || CanDoJSMoonBoots();
         }
 
-        public static bool canClearForestGlitched()
+        public static bool CanClearForestGlitched()
         {
             return (
-                canCompletePrologue()
+                CanCompletePrologue()
                 && (
                     (Randomizer.SSettings.faronWoodsLogic == FaronWoodsLogic.Open)
-                    || (canCompleteForestTemple() || CanDoLJA() || CanDoMapGlitch())
+                    || (CanCompleteForestTemple() || CanDoLJA() || CanDoMapGlitch())
                 )
             );
         }
@@ -2349,7 +2349,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanCompleteEldinTwilightGlitched()
         {
-            return Randomizer.SSettings.eldinTwilightCleared || canClearForestGlitched();
+            return Randomizer.SSettings.eldinTwilightCleared || CanClearForestGlitched();
         }
 
         /// <summary>

--- a/Generator/Logic/LogicFunctions.cs
+++ b/Generator/Logic/LogicFunctions.cs
@@ -144,7 +144,7 @@ namespace TPRandomizer
             return HasSword()
                 || CanUse(Item.Ball_and_Chain)
                 || CanUse(Item.Progressive_Bow)
-                || hasBombs()
+                || HasBombs()
                 || CanUse(Item.Iron_Boots)
                 || CanUse(Item.Shadow_Crystal)
                 || CanUse(Item.Spinner);
@@ -185,7 +185,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Shadow_Crystal)
                 || CanUse(Item.Progressive_Clawshot)
-                || hasBombs()
+                || HasBombs()
                 || CanUse(Item.Spinner)
                 || CanUseBacksliceAsSword();
         }
@@ -201,7 +201,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword();
         }
 
@@ -223,7 +223,7 @@ namespace TPRandomizer
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Slingshot)
                 || CanUse(Item.Progressive_Clawshot)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword();
         }
 
@@ -240,7 +240,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanDefeatBeamos()
         {
-            return CanUse(Item.Ball_and_Chain) || CanUse(Item.Progressive_Bow) || hasBombs();
+            return CanUse(Item.Ball_and_Chain) || CanUse(Item.Progressive_Bow) || HasBombs();
         }
 
         /// <summary>
@@ -254,7 +254,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Shadow_Crystal)
                 || CanUse(Item.Spinner)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword();
         }
 
@@ -271,7 +271,7 @@ namespace TPRandomizer
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
                 || CanUse(Item.Progressive_Clawshot)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -289,7 +289,7 @@ namespace TPRandomizer
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Slingshot)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -301,7 +301,7 @@ namespace TPRandomizer
                 || CanUse(Item.Ball_and_Chain)
                 || ((getItemCount(Item.Progressive_Bow) >= 3) && CanGetArrows())
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
                 || (CanDoDifficultCombat() && (CanUse(Item.Iron_Boots) || CanUse(Item.Spinner)))
             );
@@ -321,7 +321,7 @@ namespace TPRandomizer
                 && (
                     HasSword()
                     || CanUse(Item.Progressive_Clawshot)
-                    || (hasShield() && getItemCount(Item.Progressive_Hidden_Skill) >= 2)
+                    || (HasShield() && getItemCount(Item.Progressive_Hidden_Skill) >= 2)
                 )
             );
         }
@@ -353,7 +353,7 @@ namespace TPRandomizer
                 || CanUse(Item.Progressive_Bow)
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
             );
@@ -387,7 +387,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -403,7 +403,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Shadow_Crystal)
                 || CanUse(Item.Spinner)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -422,7 +422,7 @@ namespace TPRandomizer
                     || CanUse(Item.Spinner)
                     || CanUse(Item.Shadow_Crystal)
                     || CanUseBacksliceAsSword()
-                ) && (hasBombs() || CanUse(Item.Progressive_Clawshot))
+                ) && (HasBombs() || CanUse(Item.Progressive_Clawshot))
             );
         }
 
@@ -432,7 +432,7 @@ namespace TPRandomizer
         public static bool CanDefeatDarknut()
         {
             return HasSword()
-                || (CanDoDifficultCombat() && (hasBombs() || CanUse(Item.Ball_and_Chain)));
+                || (CanDoDifficultCombat() && (HasBombs() || CanUse(Item.Ball_and_Chain)));
         }
 
         /// <summary>
@@ -446,10 +446,10 @@ namespace TPRandomizer
                 || CanUse(Item.Progressive_Bow)
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
-                || (hasShield() && getItemCount(Item.Progressive_Hidden_Skill) >= 2)
+                || (HasShield() && getItemCount(Item.Progressive_Hidden_Skill) >= 2)
                 || CanUse(Item.Slingshot)
                 || CanUse(Item.Progressive_Clawshot)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -459,7 +459,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanDefeatDekuLike()
         {
-            return (hasBombs());
+            return (HasBombs());
         }
 
         /// <summary>
@@ -474,7 +474,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -553,11 +553,11 @@ namespace TPRandomizer
                 || CanUse(Item.Progressive_Bow)
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
-                || (hasShield() && (getItemCount(Item.Progressive_Hidden_Skill) >= 2))
+                || (HasShield() && (getItemCount(Item.Progressive_Hidden_Skill) >= 2))
                 || CanUse(Item.Slingshot)
                 || (CanDoDifficultCombat() && CanUse(Item.Lantern))
                 || CanUse(Item.Progressive_Clawshot)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -598,7 +598,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -615,7 +615,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -706,7 +706,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
             );
         }
 
@@ -721,7 +721,7 @@ namespace TPRandomizer
                 || CanUse(Item.Progressive_Bow)
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -738,7 +738,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -755,7 +755,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
             );
         }
 
@@ -786,7 +786,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -804,7 +804,7 @@ namespace TPRandomizer
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Slingshot)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -820,7 +820,7 @@ namespace TPRandomizer
                 || CanUse(Item.Progressive_Bow)
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -845,7 +845,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -861,10 +861,10 @@ namespace TPRandomizer
                 || CanUse(Item.Progressive_Bow)
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
-                || (hasShield() && getItemCount(Item.Progressive_Hidden_Skill) >= 2)
+                || (HasShield() && getItemCount(Item.Progressive_Hidden_Skill) >= 2)
                 || CanUse(Item.Slingshot)
                 || CanUse(Item.Progressive_Clawshot)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -889,7 +889,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -923,7 +923,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -969,7 +969,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -994,7 +994,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -1011,7 +1011,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -1028,7 +1028,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -1046,7 +1046,7 @@ namespace TPRandomizer
                     || CanUse(Item.Shadow_Crystal)
                     || CanUse(Item.Spinner)
                     || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
-                    || hasBombs()
+                    || HasBombs()
                     || CanUseBacksliceAsSword()
                 ) && CanUse(Item.Boomerang)
             );
@@ -1075,7 +1075,7 @@ namespace TPRandomizer
                 HasSword()
                 || CanUse(Item.Ball_and_Chain)
                 || CanUse(Item.Progressive_Bow)
-                || (hasShield() && getItemCount(Item.Progressive_Hidden_Skill) >= 2)
+                || (HasShield() && getItemCount(Item.Progressive_Hidden_Skill) >= 2)
                 || CanDoDifficultCombat() && (CanUse(Item.Shadow_Crystal))
             );
         }
@@ -1090,7 +1090,7 @@ namespace TPRandomizer
                 || CanUse(Item.Ball_and_Chain)
                 || CanUse(Item.Progressive_Bow)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
             );
         }
 
@@ -1120,7 +1120,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
             );
         }
 
@@ -1136,7 +1136,7 @@ namespace TPRandomizer
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
             );
         }
 
@@ -1159,7 +1159,7 @@ namespace TPRandomizer
                 || CanUse(Item.Progressive_Bow)
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -1175,7 +1175,7 @@ namespace TPRandomizer
                     || CanUse(Item.Shadow_Crystal)
                     || (
                         CanDoNicheStuff() && CanUse(Item.Ball_and_Chain)
-                        || (CanUse(Item.Progressive_Bow) && hasBombs())
+                        || (CanUse(Item.Progressive_Bow) && HasBombs())
                     )
                 ) && CanUse(Item.Iron_Boots)
             );
@@ -1208,7 +1208,7 @@ namespace TPRandomizer
                 || CanUse(Item.Progressive_Bow)
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUseBacksliceAsSword()
             );
         }
@@ -1245,7 +1245,7 @@ namespace TPRandomizer
                     && (
                         CanUse(Item.Spinner)
                         || CanUse(Item.Iron_Boots)
-                        || hasBombs()
+                        || HasBombs()
                         || getItemCount(Item.Progressive_Bow) >= 2
                     )
                 )
@@ -1267,7 +1267,7 @@ namespace TPRandomizer
                     && (
                         CanUse(Item.Spinner)
                         || CanUse(Item.Iron_Boots)
-                        || hasBombs()
+                        || HasBombs()
                         || CanUseBacksliceAsSword()
                     )
                 )
@@ -1301,7 +1301,7 @@ namespace TPRandomizer
                 || CanUse(Item.Progressive_Bow)
                 || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || (CanDoDifficultCombat() && CanUseBacksliceAsSword())
             );
         }
@@ -1327,7 +1327,7 @@ namespace TPRandomizer
                         || CanUse(Item.Ball_and_Chain)
                         || (CanDoNicheStuff() && CanUse(Item.Iron_Boots))
                         || CanUse(Item.Shadow_Crystal)
-                        || hasBombs()
+                        || HasBombs()
                         || (CanDoDifficultCombat() && CanUseBacksliceAsSword())
                     )
                 );
@@ -1441,7 +1441,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanSmash()
         {
-            return (CanUse(Item.Ball_and_Chain) || hasBombs());
+            return (CanUse(Item.Ball_and_Chain) || HasBombs());
         }
 
         /// <summary>
@@ -1449,13 +1449,13 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanBurnWebs()
         {
-            return CanUse(Item.Lantern) || hasBombs() || CanUse(Item.Ball_and_Chain);
+            return CanUse(Item.Lantern) || HasBombs() || CanUse(Item.Ball_and_Chain);
         }
 
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool hasRangedItem()
+        public static bool HasRangedItem()
         {
             return (
                 CanUse(Item.Ball_and_Chain)
@@ -1469,7 +1469,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool hasShield()
+        public static bool HasShield()
         {
             return (
                 CanUse(Item.Hylian_Shield)
@@ -1505,7 +1505,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanLaunchBombs()
         {
-            return ((CanUse(Item.Boomerang) || CanUse(Item.Progressive_Bow)) && hasBombs());
+            return ((CanUse(Item.Boomerang) || CanUse(Item.Progressive_Bow)) && HasBombs());
         }
 
         /// <summary>
@@ -1541,7 +1541,7 @@ namespace TPRandomizer
                 || (
                     CanDoNicheStuff()
                     && (
-                        hasBombs()
+                        HasBombs()
                         || (HasSword() && getItemCount(Item.Progressive_Hidden_Skill) >= 6)
                     )
                 )
@@ -1563,12 +1563,12 @@ namespace TPRandomizer
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Ball_and_Chain)
                 || CanUse(Item.Shadow_Crystal)
-                || hasBombs()
+                || HasBombs()
                 || CanUse(Item.Progressive_Bow)
                 || CanUse(Item.Progressive_Clawshot)
                 || (
                     CanDoNicheStuff()
-                    && hasShield()
+                    && HasShield()
                     && getItemCount(Item.Progressive_Hidden_Skill) >= 2
                 )
             );
@@ -1593,7 +1593,7 @@ namespace TPRandomizer
                     CanUse(Item.Lantern)
                     || (
                         (Randomizer.SSettings.smallKeySettings == SmallKeySettings.Keysy)
-                        && (hasBombs() || CanUse(Item.Iron_Boots))
+                        && (HasBombs() || CanUse(Item.Iron_Boots))
                     )
                 )
                 && CanBurnWebs()
@@ -1632,7 +1632,7 @@ namespace TPRandomizer
         /// <summary>
         /// summary text.
         /// </summary>
-        public static bool hasBombs()
+        public static bool HasBombs()
         {
             return (
                 CanUse(Item.Filled_Bomb_Bag)
@@ -2283,7 +2283,7 @@ namespace TPRandomizer
             return CanDoMoonBoots()
                 && getItemCount(Item.Progressive_Hidden_Skill) >= 4
                 && HasSword()
-                && hasShield();
+                && HasShield();
         }
 
         /// <summary>
@@ -2318,7 +2318,7 @@ namespace TPRandomizer
                     && (
                         CanUse(Item.Shadow_Crystal)
                         || HasSword()
-                        || hasBombs()
+                        || HasBombs()
                         || CanUse(Item.Iron_Boots)
                         || CanUse(Item.Spinner)
                     )
@@ -2330,7 +2330,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanDoFTWindlessBridgeRoom()
         {
-            return hasBombs() || CanDoBSMoonBoots() || CanDoJSMoonBoots();
+            return HasBombs() || CanDoBSMoonBoots() || CanDoJSMoonBoots();
         }
 
         public static bool CanClearForestGlitched()
@@ -2363,7 +2363,7 @@ namespace TPRandomizer
                 || CanDoJSMoonBoots()
                 || CanDoLJA()
                 || (
-                    hasBombs()
+                    HasBombs()
                     && (HasHeavyMod() || getItemCount(Item.Progressive_Hidden_Skill) >= 6)
                 );
         }

--- a/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds Big Key Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds Big Key Chest.jsonc
@@ -1,7 +1,7 @@
 {
-  "requirements": "(Arbiters_Grounds_Small_Key, 5) and (Progressive_Clawshot, 1) and Spinner and canSmash",
+  "requirements": "(Arbiters_Grounds_Small_Key, 5) and (Progressive_Clawshot, 1) and Spinner and CanSmash",
   // Either going around or just doing Wolf clip.
-  "glitchedRequirements": "(((Arbiters_Grounds_Small_Key, 5) or ((Arbiters_Grounds_Small_Key, 4) and Shadow_Crystal)) and (Progressive_Clawshot, 1) and Spinner and canSmash)",
+  "glitchedRequirements": "(((Arbiters_Grounds_Small_Key, 5) or ((Arbiters_Grounds_Small_Key, 4) and Shadow_Crystal)) and (Progressive_Clawshot, 1) and Spinner and CanSmash)",
   "checkCategory": [ "Chest", "Dungeon", "Arbiters Grounds", "Big Key"],
   "itemId": "Arbiters_Grounds_Big_Key"
 }

--- a/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds Entrance Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds Entrance Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canBreakWoodenDoor",
-    "glitchedRequirements": "canBreakWoodenDoor",
+    "requirements": "CanBreakWoodenDoor",
+    "glitchedRequirements": "CanBreakWoodenDoor",
     "checkCategory": ["Chest", "Dungeon", "Arbiters Grounds", "Small Key"],
     "itemId": "Arbiters_Grounds_Small_Key"
 }

--- a/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds West Poe.jsonc
+++ b/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds West Poe.jsonc
@@ -1,7 +1,7 @@
 {
-  "requirements": "Shadow_Crystal and canSmash and (Arbiters_Grounds_Small_Key, 4) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat",
+  "requirements": "Shadow_Crystal and CanSmash and (Arbiters_Grounds_Small_Key, 4) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat",
   // Either coming from East Wing or doing Poe 1 Skip LJA
-  "glitchedRequirements": "Shadow_Crystal and canSmash and (((Arbiters_Grounds_Small_Key, 4) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat) or CanDoLJA)",
+  "glitchedRequirements": "Shadow_Crystal and CanSmash and (((Arbiters_Grounds_Small_Key, 4) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat) or CanDoLJA)",
   "checkCategory": [ "Dungeon", "Poe", "Arbiters Grounds" ],
   "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds West Stalfos Northeast Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds West Stalfos Northeast Chest.jsonc
@@ -1,7 +1,7 @@
 {
-  "requirements": "canBreakWoodenDoor and (Arbiters_Grounds_Small_Key, 4) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat",
+  "requirements": "CanBreakWoodenDoor and (Arbiters_Grounds_Small_Key, 4) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat",
   // Either coming from East Wing or doing Poe 1 Skip LJA
-  "glitchedRequirements": "canBreakWoodenDoor and (((Arbiters_Grounds_Small_Key, 4) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat) or CanDoLJA)",
+  "glitchedRequirements": "CanBreakWoodenDoor and (((Arbiters_Grounds_Small_Key, 4) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat) or CanDoLJA)",
   "checkCategory": [ "Chest", "Dungeon", "Arbiters Grounds" ],
   "itemId": "Bombs_5"
 }

--- a/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds West Stalfos West Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds West Stalfos West Chest.jsonc
@@ -1,6 +1,6 @@
 {
-  "requirements": "canBreakWoodenDoor and (Arbiters_Grounds_Small_Key, 4) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat",
-  "glitchedRequirements": "canBreakWoodenDoor and (((Arbiters_Grounds_Small_Key, 4) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat) or CanDoLJA)",
+  "requirements": "CanBreakWoodenDoor and (Arbiters_Grounds_Small_Key, 4) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat",
+  "glitchedRequirements": "CanBreakWoodenDoor and (((Arbiters_Grounds_Small_Key, 4) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat) or CanDoLJA)",
   "checkCategory": [ "Chest", "Dungeon", "Arbiters Grounds" ],
   "itemId": "Bombs_5"
 }

--- a/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple Central Chest Hanging From Web.jsonc
+++ b/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple Central Chest Hanging From Web.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canCutHangingWeb",
-    "glitchedRequirements": "canCutHangingWeb or CanDoJSMoonBoots",
+    "requirements": "CanCutHangingWeb",
+    "glitchedRequirements": "CanCutHangingWeb or CanDoJSMoonBoots",
     "checkCategory": ["Chest", "Dungeon", "Forest Temple", "Dungeon Items", "Compass"],
     "itemId": "Forest_Temple_Compass"
 }

--- a/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple East Tile Worm Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple East Tile Worm Chest.jsonc
@@ -1,6 +1,6 @@
 {
   "requirements": "CanDefeatTileWorm and CanDefeatSkulltula and CanDefeatWalltula and Boomerang and (Forest_Temple_Small_Key, 4)",
-  "glitchedRequirements": "(hasBombs or CanDoBSMoonBoots or CanDoJSMoonBoots or Boomerang) and (Forest_Temple_Small_Key, 4)",
+  "glitchedRequirements": "(HasBombs or CanDoBSMoonBoots or CanDoJSMoonBoots or Boomerang) and (Forest_Temple_Small_Key, 4)",
   "checkCategory": [ "Chest", "Dungeon", "Forest Temple"],
   "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple Gale Boomerang.jsonc
+++ b/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple Gale Boomerang.jsonc
@@ -1,6 +1,6 @@
 {
     "requirements": "CanDefeatOok",
-    "glitchedRequirements": "CanDefeatOok or hasBombs",
+    "glitchedRequirements": "CanDefeatOok or HasBombs",
     "checkCategory": ["Forest Temple", "Dungeon", "Boss"],
     "itemId": "Boomerang"
 }

--- a/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple North Deku Like Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple North Deku Like Chest.jsonc
@@ -1,6 +1,6 @@
 {
     "requirements": "Boomerang",
-    "glitchedRequirements": "Boomerang or (hasBombs and HasSword and (Progressive_Clawshot, 1))",
+    "glitchedRequirements": "Boomerang or (HasBombs and HasSword and (Progressive_Clawshot, 1))",
     "checkCategory": ["Chest", "Dungeon", "Forest Temple", "Small Key"],
     "itemId": "Forest_Temple_Small_Key"
 }

--- a/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple Totem Pole Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple Totem Pole Chest.jsonc
@@ -1,6 +1,6 @@
 {
     "requirements": "true",
-    "glitchedRequirements": "CanDefeatBombling or canSmash",
+    "glitchedRequirements": "CanDefeatBombling or CanSmash",
     "checkCategory": ["Chest", "Dungeon", "Forest Temple", "Small Key"],
     "itemId": "Forest_Temple_Small_Key"
 }

--- a/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple West Tile Worm Chest Behind Stairs.jsonc
+++ b/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple West Tile Worm Chest Behind Stairs.jsonc
@@ -1,6 +1,6 @@
 {
     "requirements": "Boomerang",
-    "glitchedRequirements": "Boomerang and (CanDefeatBombling or canSmash)",
+    "glitchedRequirements": "Boomerang and (CanDefeatBombling or CanSmash)",
     "checkCategory": ["Chest", "Dungeon", "Forest Temple"],
     "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple West Tile Worm Room Vines Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Forest Temple/Forest Temple West Tile Worm Room Vines Chest.jsonc
@@ -1,6 +1,6 @@
 {
     "requirements": "true",
-    "glitchedRequirements": "CanDefeatBombling or canSmash",
+    "glitchedRequirements": "CanDefeatBombling or CanSmash",
     "checkCategory": ["Chest", "Dungeon", "Forest Temple"],
     "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Dungeons/Goron Mines/Goron Mines Entrance Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Goron Mines/Goron Mines Entrance Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canPressMinesSwitch and canBreakWoodenDoor",
-    "glitchedRequirements": "CanDoBSMoonBoots or canBreakWoodenDoor",
+    "requirements": "CanPressMinesSwitch and CanBreakWoodenDoor",
+    "glitchedRequirements": "CanDoBSMoonBoots or CanBreakWoodenDoor",
     "checkCategory": ["Chest", "Dungeon", "Goron Mines"],
     "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Graveyard Grave Switch Room Back Left Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Graveyard Grave Switch Room Back Left Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Chest", "Dungeon", "Hyrule Castle"],
     "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Graveyard Grave Switch Room Front Left Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Graveyard Grave Switch Room Front Left Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Chest", "Dungeon", "Hyrule Castle"],
     "itemId": "Green_Rupee"
 }

--- a/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Graveyard Grave Switch Room Right Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Graveyard Grave Switch Room Right Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Chest", "Dungeon", "Hyrule Castle"],
     "itemId": "Orange_Rupee"
 }

--- a/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Graveyard Owl Statue Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Hyrule Castle/Hyrule Castle Graveyard Owl Statue Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern and (Progressive_Dominion_Rod, 2)",
-    "glitchedRequirements": "canSmash and Lantern and (Progressive_Dominion_Rod, 2)",
+    "requirements": "CanSmash and Lantern and (Progressive_Dominion_Rod, 2)",
+    "glitchedRequirements": "CanSmash and Lantern and (Progressive_Dominion_Rod, 2)",
     "checkCategory": ["Chest", "Dungeon", "Hyrule Castle", "Small Key"],
     "itemId": "Hyrule_Castle_Small_Key"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Before Deku Toad Alcove Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Before Deku Toad Alcove Chest.jsonc
@@ -12,8 +12,8 @@
   // pass the underwater chests in order to get the key from this chest in order
   // to access the underwater chests which they just walked past. This can lead
   // to nonsensical Path hints.
-  "requirements": "((Setting.smallKeySettings equals Vanilla) and CanDefeatDekuToad and (Lakebed_Temple_Small_Key, 2) and Zora_Armor and Iron_Boots and CanUseWaterBombs and (Progressive_Clawshot, 1)) or ((Lakebed_Temple_Small_Key,3) and (canLaunchBombs or ((Progressive_Clawshot, 1) and canSmash)))",
-  "glitchedRequirements": "CanDoLJA or ((Lakebed_Temple_Small_Key, 2) and (canLaunchBombs or (Progressive_Clawshot, 1)))",
+  "requirements": "((Setting.smallKeySettings equals Vanilla) and CanDefeatDekuToad and (Lakebed_Temple_Small_Key, 2) and Zora_Armor and Iron_Boots and CanUseWaterBombs and (Progressive_Clawshot, 1)) or ((Lakebed_Temple_Small_Key,3) and (CanLaunchBombs or ((Progressive_Clawshot, 1) and CanSmash)))",
+  "glitchedRequirements": "CanDoLJA or ((Lakebed_Temple_Small_Key, 2) and (CanLaunchBombs or (Progressive_Clawshot, 1)))",
     "checkCategory": ["Chest", "Dungeon", "Lakebed Temple", "Small Key"],
   "itemId": "Lakebed_Temple_Small_Key"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Before Deku Toad Underwater Left Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Before Deku Toad Underwater Left Chest.jsonc
@@ -1,6 +1,6 @@
 {
-  "requirements": "Zora_Armor and Iron_Boots and (Lakebed_Temple_Small_Key, 3) and (canLaunchBombs or ((Progressive_Clawshot, 1) and canSmash))",
-  "glitchedRequirements": "((CanDoLJA and (CanSkipKeyToDekuToad or (Lakebed_Temple_Small_Key, 1))) or ((CanSkipKeyToDekuToad or (Lakebed_Temple_Small_Key, 3)) and (Progressive_Clawshot, 1) and canLaunchBombs)) and HasHeavyMod",
+  "requirements": "Zora_Armor and Iron_Boots and (Lakebed_Temple_Small_Key, 3) and (CanLaunchBombs or ((Progressive_Clawshot, 1) and CanSmash))",
+  "glitchedRequirements": "((CanDoLJA and (CanSkipKeyToDekuToad or (Lakebed_Temple_Small_Key, 1))) or ((CanSkipKeyToDekuToad or (Lakebed_Temple_Small_Key, 3)) and (Progressive_Clawshot, 1) and CanLaunchBombs)) and HasHeavyMod",
   "checkCategory": [ "Chest", "Dungeon", "Lakebed Temple"],
   "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Before Deku Toad Underwater Right Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Before Deku Toad Underwater Right Chest.jsonc
@@ -1,6 +1,6 @@
 {
-  "requirements": "Zora_Armor and Iron_Boots and (Lakebed_Temple_Small_Key, 3) and (canLaunchBombs or ((Progressive_Clawshot, 1) and canSmash))",
-  "glitchedRequirements": "((CanDoLJA and (CanSkipKeyToDekuToad or (Lakebed_Temple_Small_Key, 1)))) or ((CanSkipKeyToDekuToad or (Lakebed_Temple_Small_Key, 3)) and (Progressive_Clawshot, 1) and canLaunchBombs) and HasHeavyMod",
+  "requirements": "Zora_Armor and Iron_Boots and (Lakebed_Temple_Small_Key, 3) and (CanLaunchBombs or ((Progressive_Clawshot, 1) and CanSmash))",
+  "glitchedRequirements": "((CanDoLJA and (CanSkipKeyToDekuToad or (Lakebed_Temple_Small_Key, 1)))) or ((CanSkipKeyToDekuToad or (Lakebed_Temple_Small_Key, 3)) and (Progressive_Clawshot, 1) and CanLaunchBombs) and HasHeavyMod",
   "checkCategory": [ "Chest", "Dungeon", "Lakebed Temple" ],
   "itemId": "Water_Bombs_5"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Big Key Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Big Key Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "(Progressive_Clawshot, 1) and CanUseWaterBombs and Zora_Armor and canLaunchBombs and Iron_Boots",
-    "glitchedRequirements": "(Progressive_Clawshot, 1) and (Zora_Armor or CanDoLJA) and canLaunchBombs",
+    "requirements": "(Progressive_Clawshot, 1) and CanUseWaterBombs and Zora_Armor and CanLaunchBombs and Iron_Boots",
+    "glitchedRequirements": "(Progressive_Clawshot, 1) and (Zora_Armor or CanDoLJA) and CanLaunchBombs",
     "checkCategory": ["Chest", "Dungeon", "Lakebed Temple", "Big Key"],
     "itemId": "Lakebed_Temple_Big_Key"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Central Room Spire Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Central Room Spire Chest.jsonc
@@ -1,6 +1,6 @@
 {
-  "requirements": "(Lakebed_Temple_Small_Key, 3) and Iron_Boots and canLaunchBombs",
-  "glitchedRequirements": "(((Lakebed_Temple_Small_Key, 3) and canLaunchBombs) or (Progressive_Clawshot and HasSword)) and Iron_Boots",
+  "requirements": "(Lakebed_Temple_Small_Key, 3) and Iron_Boots and CanLaunchBombs",
+  "glitchedRequirements": "(((Lakebed_Temple_Small_Key, 3) and CanLaunchBombs) or (Progressive_Clawshot and HasSword)) and Iron_Boots",
   "checkCategory": [ "Chest", "Dungeon", "Lakebed Temple"],
   "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Deku Toad Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Deku Toad Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "CanDefeatDekuToad and (Lakebed_Temple_Small_Key, 3) and Zora_Armor and Iron_Boots and CanUseWaterBombs and (canLaunchBombs or ((Progressive_Clawshot, 1) and canSmash))",
-    "glitchedRequirements": "CanDefeatDekuToad and (((CanDoLJA and (CanSkipKeyToDekuToad or (Lakebed_Temple_Small_Key, 1)))) or ((CanSkipKeyToDekuToad or (Lakebed_Temple_Small_Key, 3)) and (Progressive_Clawshot, 1) and canLaunchBombs)) and HasHeavyMod and (CanUseWaterBombs or Zora_Armor)",
+    "requirements": "CanDefeatDekuToad and (Lakebed_Temple_Small_Key, 3) and Zora_Armor and Iron_Boots and CanUseWaterBombs and (CanLaunchBombs or ((Progressive_Clawshot, 1) and CanSmash))",
+    "glitchedRequirements": "CanDefeatDekuToad and (((CanDoLJA and (CanSkipKeyToDekuToad or (Lakebed_Temple_Small_Key, 1)))) or ((CanSkipKeyToDekuToad or (Lakebed_Temple_Small_Key, 3)) and (Progressive_Clawshot, 1) and CanLaunchBombs)) and HasHeavyMod and (CanUseWaterBombs or Zora_Armor)",
     "checkCategory": ["Chest", "Dungeon", "Lakebed Temple"],
     "itemId": "Progressive_Clawshot"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple East Lower Waterwheel Bridge Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple East Lower Waterwheel Bridge Chest.jsonc
@@ -1,6 +1,6 @@
 {
   "requirements": "(Progressive_Clawshot, 1) and (Lakebed_Temple_Small_Key, 3) and CanLaunchBombs",
-  "glitchedRequirements": "CanDoLJA or ((Progressive_Clawshot, 1) and hasBombs) or (Room.Lakebed_Temple_East_Wing_Second_Floor and ((Progressive_Clawshot, 1) or CanLaunchBombs) and ((Shadow_Crystal or (hasBombs and HasSword)))) or (Room.Lakebed_Temple_West_Wing and CanLaunchBombs)",
+  "glitchedRequirements": "CanDoLJA or ((Progressive_Clawshot, 1) and HasBombs) or (Room.Lakebed_Temple_East_Wing_Second_Floor and ((Progressive_Clawshot, 1) or CanLaunchBombs) and ((Shadow_Crystal or (HasBombs and HasSword)))) or (Room.Lakebed_Temple_West_Wing and CanLaunchBombs)",
   "checkCategory": [ "Chest", "Dungeon", "Lakebed Temple"],
   "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple East Lower Waterwheel Bridge Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple East Lower Waterwheel Bridge Chest.jsonc
@@ -1,6 +1,6 @@
 {
-  "requirements": "(Progressive_Clawshot, 1) and (Lakebed_Temple_Small_Key, 3) and canLaunchBombs",
-  "glitchedRequirements": "CanDoLJA or ((Progressive_Clawshot, 1) and hasBombs) or (Room.Lakebed_Temple_East_Wing_Second_Floor and ((Progressive_Clawshot, 1) or canLaunchBombs) and ((Shadow_Crystal or (hasBombs and HasSword)))) or (Room.Lakebed_Temple_West_Wing and canLaunchBombs)",
+  "requirements": "(Progressive_Clawshot, 1) and (Lakebed_Temple_Small_Key, 3) and CanLaunchBombs",
+  "glitchedRequirements": "CanDoLJA or ((Progressive_Clawshot, 1) and hasBombs) or (Room.Lakebed_Temple_East_Wing_Second_Floor and ((Progressive_Clawshot, 1) or CanLaunchBombs) and ((Shadow_Crystal or (hasBombs and HasSword)))) or (Room.Lakebed_Temple_West_Wing and CanLaunchBombs)",
   "checkCategory": [ "Chest", "Dungeon", "Lakebed Temple"],
   "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple East Lower Waterwheel Stalactite Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple East Lower Waterwheel Stalactite Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canLaunchBombs",
-    "glitchedRequirements": "canLaunchBombs or CanDoLJA",
+    "requirements": "CanLaunchBombs",
+    "glitchedRequirements": "CanLaunchBombs or CanDoLJA",
     "checkCategory": ["Chest", "Dungeon", "Lakebed Temple", "Small Key"],
     "itemId": "Lakebed_Temple_Small_Key"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple East Second Floor Southeast Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple East Second Floor Southeast Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canLaunchBombs or ((Progressive_Clawshot, 1) and canSmash)",
-    "glitchedRequirements": "canLaunchBombs or ((Progressive_Clawshot, 1) and canSmash)",
+    "requirements": "CanLaunchBombs or ((Progressive_Clawshot, 1) and CanSmash)",
+    "glitchedRequirements": "CanLaunchBombs or ((Progressive_Clawshot, 1) and CanSmash)",
     "checkCategory": ["Chest", "Dungeon", "Lakebed Temple", "Small Key"],
     "itemId": "Lakebed_Temple_Small_Key"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Stalactite Room Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Stalactite Room Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canLaunchBombs",
-    "glitchedRequirements": "canLaunchBombs or CanDoLJA",
+    "requirements": "CanLaunchBombs",
+    "glitchedRequirements": "CanLaunchBombs or CanDoLJA",
     "checkCategory": ["Chest", "Dungeon", "Lakebed Temple"],
     "itemId": "Water_Bombs_10"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Underwater Maze Small Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Underwater Maze Small Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "Zora_Armor and (Progressive_Clawshot,1) and canLaunchBombs",
-    "glitchedRequirements": "(Progressive_Clawshot, 1) and (Zora_Armor or CanDoLJA) and canLaunchBombs",
+    "requirements": "Zora_Armor and (Progressive_Clawshot,1) and CanLaunchBombs",
+    "glitchedRequirements": "(Progressive_Clawshot, 1) and (Zora_Armor or CanDoLJA) and CanLaunchBombs",
     "checkCategory": ["Chest", "Dungeon", "Lakebed Temple"],
     "itemId": "Water_Bombs_5"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple West Second Floor Northeast Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple West Second Floor Northeast Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "(Progressive_Clawshot, 1) and canLaunchBombs",
-    "glitchedRequirements": "(Progressive_Clawshot, 1) and canLaunchBombs",
+    "requirements": "(Progressive_Clawshot, 1) and CanLaunchBombs",
+    "glitchedRequirements": "(Progressive_Clawshot, 1) and CanLaunchBombs",
     "checkCategory": ["Chest", "Dungeon", "Lakebed Temple"],
     "itemId": "Water_Bombs_15"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple West Second Floor Southeast Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple West Second Floor Southeast Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "(Progressive_Clawshot, 1) and canLaunchBombs",
-    "glitchedRequirements": "(Progressive_Clawshot, 1) and canLaunchBombs",
+    "requirements": "(Progressive_Clawshot, 1) and CanLaunchBombs",
+    "glitchedRequirements": "(Progressive_Clawshot, 1) and CanLaunchBombs",
     "checkCategory": ["Chest", "Dungeon", "Lakebed Temple"],
     "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple West Second Floor Southwest Underwater Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple West Second Floor Southwest Underwater Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "(Progressive_Clawshot, 1) and Iron_Boots and canLaunchBombs",
-    "glitchedRequirements": "(Progressive_Clawshot, 1) and Iron_Boots and canLaunchBombs",
+    "requirements": "(Progressive_Clawshot, 1) and Iron_Boots and CanLaunchBombs",
+    "glitchedRequirements": "(Progressive_Clawshot, 1) and Iron_Boots and CanLaunchBombs",
     "checkCategory": ["Chest", "Dungeon", "Lakebed Temple"],
     "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple West Water Supply Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple West Water Supply Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "(Progressive_Clawshot, 1) and canLaunchBombs and Iron_Boots",
-    "glitchedRequirements": "(Progressive_Clawshot, 1) and canLaunchBombs",
+    "requirements": "(Progressive_Clawshot, 1) and CanLaunchBombs and Iron_Boots",
+    "glitchedRequirements": "(Progressive_Clawshot, 1) and CanLaunchBombs",
     "checkCategory": ["Chest", "Dungeon", "Lakebed Temple", "Dungeon Items", "Compass"],
     "itemId": "Lakebed_Temple_Compass"
 }

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple West Water Supply Small Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple West Water Supply Small Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "(Progressive_Clawshot, 1) and canLaunchBombs and Iron_Boots",
-    "glitchedRequirements": "(Progressive_Clawshot, 1) and canLaunchBombs",
+    "requirements": "(Progressive_Clawshot, 1) and CanLaunchBombs and Iron_Boots",
+    "glitchedRequirements": "(Progressive_Clawshot, 1) and CanLaunchBombs",
     "checkCategory": ["Chest", "Dungeon", "Lakebed Temple"],
     "itemId": "Water_Bombs_10"
 }

--- a/Generator/World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Courtyard Central Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Courtyard Central Chest.jsonc
@@ -1,7 +1,7 @@
 {
     //Don't require gate to be unlocked for cannonballs if we have Cheese since we can get to the otherside by going through Yeta's room.
-    "requirements": "Ball_and_Chain or (hasBombs and (((Snowpeak_Ruins_Small_Key, 2) or Snowpeak_Ruins_Ordon_Goat_Cheese)))",
-    "glitchedRequirements": "Ball_and_Chain or (hasBombs and ((Snowpeak_Ruins_Small_Key, 2)))",
+    "requirements": "Ball_and_Chain or (HasBombs and (((Snowpeak_Ruins_Small_Key, 2) or Snowpeak_Ruins_Ordon_Goat_Cheese)))",
+    "glitchedRequirements": "Ball_and_Chain or (HasBombs and ((Snowpeak_Ruins_Small_Key, 2)))",
     "checkCategory": ["Chest", "Dungeon", "Snowpeak Ruins"],
     "itemId": "Bombs_5"
 }

--- a/Generator/World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins West Cannon Room Corner Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins West Cannon Room Corner Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Chest", "Dungeon", "Snowpeak Ruins"],
     "itemId": "Bombs_5"
 }

--- a/Generator/World/Checks/Dungeons/Temple of Time/Temple of Time First Staircase Armos Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Temple of Time/Temple of Time First Staircase Armos Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "CanDefeatArmos and hasRangedItem",
-    "glitchedRequirements": "CanDefeatArmos and hasRangedItem",
+    "requirements": "CanDefeatArmos and HasRangedItem",
+    "glitchedRequirements": "CanDefeatArmos and HasRangedItem",
     "checkCategory": ["Chest", "Dungeon", "Temple of Time", "Dungeon Items", "Dungeon Map"],
     "itemId": "Temple_of_Time_Dungeon_Map"
 }

--- a/Generator/World/Checks/Dungeons/Temple of Time/Temple of Time First Staircase Window Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Temple of Time/Temple of Time First Staircase Window Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "hasRangedItem",
-    "glitchedRequirements": "hasRangedItem",
+    "requirements": "HasRangedItem",
+    "glitchedRequirements": "HasRangedItem",
     "checkCategory": ["Chest", "Dungeon", "Temple of Time"],
     "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Dungeons/Temple of Time/Temple of Time Moving Wall Dinalfos Room Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Temple of Time/Temple of Time Moving Wall Dinalfos Room Chest.jsonc
@@ -1,6 +1,6 @@
 {
     "requirements": "CanDefeatDinalfos and (Progressive_Dominion_Rod, 1) and (Progressive_Bow, 1)",
-    "glitchedRequirements": "CanDefeatDinalfos and ((Progressive_Dominion_Rod, 1) or (Spinner and hasBombs)) and (Progressive_Bow, 1)",
+    "glitchedRequirements": "CanDefeatDinalfos and ((Progressive_Dominion_Rod, 1) or (Spinner and HasBombs)) and (Progressive_Bow, 1)",
     "checkCategory": ["Chest", "Dungeon", "Temple of Time"],
     "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Overworld/Eldin Province/Death Mountain Alcove Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Death Mountain Alcove Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "(canCompleteGoronMines and (Setting.barrenDungeons equals False)) or (Progressive_Clawshot, 1)",
-    "glitchedRequirements": "(canCompleteGoronMines and (Setting.barrenDungeons equals False)) or (Progressive_Clawshot, 1) or CanDoLJA",
+    "requirements": "(CanCompleteGoronMines and (Setting.barrenDungeons equals False)) or (Progressive_Clawshot, 1)",
+    "glitchedRequirements": "(CanCompleteGoronMines and (Setting.barrenDungeons equals False)) or (Progressive_Clawshot, 1) or CanDoLJA",
     "checkCategory": ["Overworld", "Chest", "Death Mountain"],
     "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Overworld/Eldin Province/Death Mountain Trail Poe.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Death Mountain Trail Poe.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "Shadow_Crystal and canCompleteGoronMines and CanCompleteEldinTwilight",
-    "glitchedRequirements": "Shadow_Crystal and canCompleteGoronMines and CanCompleteEldinTwilight",
+    "requirements": "Shadow_Crystal and CanCompleteGoronMines and CanCompleteEldinTwilight",
+    "glitchedRequirements": "Shadow_Crystal and CanCompleteGoronMines and CanCompleteEldinTwilight",
     "checkCategory": ["Overworld", "Poe", "Death Mountain"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Overworld/Eldin Province/Eldin Field Bomb Rock Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Eldin Field Bomb Rock Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash",
-    "glitchedRequirements": "canSmash or (CanDoMapGlitch and CanCompleteEldinTwilight) or (CanDoEBMoonBoots and CanDoLJA and CanCompleteEldinTwilight)",
+    "requirements": "CanSmash",
+    "glitchedRequirements": "CanSmash or (CanDoMapGlitch and CanCompleteEldinTwilight) or (CanDoEBMoonBoots and CanDoLJA and CanCompleteEldinTwilight)",
     "checkCategory": ["Overworld", "Chest", "Hyrule Field - Eldin Province"],
     "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Overworld/Eldin Province/Eldin Lantern Cave First Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Eldin Lantern Cave First Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canBurnWebs",
-    "glitchedRequirements": "canBurnWebs",
+    "requirements": "CanBurnWebs",
+    "glitchedRequirements": "CanBurnWebs",
     "checkCategory": ["Overworld", "Chest", "Eldin Lantern Cave", "ARC"],
     "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Eldin Province/Eldin Lantern Cave Poe.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Eldin Lantern Cave Poe.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "Shadow_Crystal and canBurnWebs",
-    "glitchedRequirements": "Shadow_Crystal and canBurnWebs",
+    "requirements": "Shadow_Crystal and CanBurnWebs",
+    "glitchedRequirements": "Shadow_Crystal and CanBurnWebs",
     "checkCategory": ["Overworld", "Poe", "Eldin Lantern Cave"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Overworld/Eldin Province/Eldin Lantern Cave Second Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Eldin Lantern Cave Second Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canBurnWebs",
-    "glitchedRequirements": "canBurnWebs",
+    "requirements": "CanBurnWebs",
+    "glitchedRequirements": "CanBurnWebs",
     "checkCategory": ["Overworld", "Chest", "Eldin Lantern Cave"],
     "itemId": "Purple_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Eldin Province/Eldin Spring Underwater Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Eldin Spring Underwater Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Iron_Boots",
-    "glitchedRequirements": "HasHeavyMod and (canSmash or CanDoMapGlitch)",
+    "requirements": "CanSmash and Iron_Boots",
+    "glitchedRequirements": "HasHeavyMod and (CanSmash or CanDoMapGlitch)",
     "checkCategory": ["Overworld", "Chest", "Kakariko Village"],
     "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Overworld/Eldin Province/Goron Springwater Rush.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Goron Springwater Rush.jsonc
@@ -3,7 +3,7 @@
   // we don't want this logic to exist because we don't want to have the bridge donation in logic for lanayru access
   // and having this check with a differing logic could confuse the player if they are required to get this check, but 
   // then it is not in logic for them to just walk into the castle town.
-  "requirements": "canSmash or (((Setting.lanayruTwilightCleared equals True) or Shadow_Crystal) and Gate_Keys) and CanCompleteEldinTwilight",
+  "requirements": "CanSmash or (((Setting.lanayruTwilightCleared equals True) or Shadow_Crystal) and Gate_Keys) and CanCompleteEldinTwilight",
   "glitchedRequirements": "Room.Kakariko_Malo_Mart and Room.Lower_Kakariko_Village and CanCompleteEldinTwilight",
   "checkCategory": [ "Overworld", "Npc", "Hyrule Field - Eldin Province", "Boss" ],
   "itemId": "Piece_of_Heart"

--- a/Generator/World/Checks/Overworld/Eldin Province/Kakariko Village Bell Rupee.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Kakariko Village Bell Rupee.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canLaunchBombs and (Shadow_Crystal or Boomerang)",
-    "glitchedRequirements": "canLaunchBombs and (Shadow_Crystal or Boomerang)",
+    "requirements": "CanLaunchBombs and (Shadow_Crystal or Boomerang)",
+    "glitchedRequirements": "CanLaunchBombs and (Shadow_Crystal or Boomerang)",
     "checkCategory": ["Overworld", "Kakariko Village", "Rupee - Hidden"],
     "itemId": "Silver_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Eldin Province/Kakariko Village Bomb Rock Spire Heart Piece.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Kakariko Village Bomb Rock Spire Heart Piece.jsonc
@@ -1,6 +1,6 @@
 {
     "requirements": "hasBombs and Boomerang and CanCompleteEldinTwilight",
-    "glitchedRequirements": "(CanDoMapGlitch or (canLaunchBombs and (Boomerang or (Progressive_Clawshot, 1)))) and CanCompleteEldinTwilight",
+    "glitchedRequirements": "(CanDoMapGlitch or (CanLaunchBombs and (Boomerang or (Progressive_Clawshot, 1)))) and CanCompleteEldinTwilight",
     "checkCategory": ["Overworld", "Chest", "Kakariko Village"],
     "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Overworld/Eldin Province/Kakariko Village Bomb Rock Spire Heart Piece.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Kakariko Village Bomb Rock Spire Heart Piece.jsonc
@@ -1,5 +1,5 @@
 {
-    "requirements": "hasBombs and Boomerang and CanCompleteEldinTwilight",
+    "requirements": "HasBombs and Boomerang and CanCompleteEldinTwilight",
     "glitchedRequirements": "(CanDoMapGlitch or (CanLaunchBombs and (Boomerang or (Progressive_Clawshot, 1)))) and CanCompleteEldinTwilight",
     "checkCategory": ["Overworld", "Chest", "Kakariko Village"],
     "itemId": "Piece_of_Heart"

--- a/Generator/World/Checks/Overworld/Eldin Province/Kakariko Village Malo Mart Hawkeye.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Kakariko Village Malo Mart Hawkeye.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canCompleteGoronMines and Room.Kakariko_Top_of_Watchtower and (Progressive_Bow, 1) and CanChangeTime and CanCompleteEldinTwilight",
-    "glitchedRequirements": "canCompleteGoronMines and Room.Kakariko_Top_of_Watchtower and (Progressive_Bow, 1) and CanChangeTime and CanCompleteEldinTwilight",
+    "requirements": "CanCompleteGoronMines and Room.Kakariko_Top_of_Watchtower and (Progressive_Bow, 1) and CanChangeTime and CanCompleteEldinTwilight",
+    "glitchedRequirements": "CanCompleteGoronMines and Room.Kakariko_Top_of_Watchtower and (Progressive_Bow, 1) and CanChangeTime and CanCompleteEldinTwilight",
     "checkCategory": ["Overworld", "Kakariko Village", "ARC", "Shop"],
     "itemId": "Hawkeye"
 }

--- a/Generator/World/Checks/Overworld/Eldin Province/Kakariko Watchtower Alcove Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Kakariko Watchtower Alcove Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and CanCompleteEldinTwilight",
-    "glitchedRequirements": "(canSmash and CanCompleteEldinTwilight) or Shadow_Crystal",
+    "requirements": "CanSmash and CanCompleteEldinTwilight",
+    "glitchedRequirements": "(CanSmash and CanCompleteEldinTwilight) or Shadow_Crystal",
     "checkCategory": ["Overworld", "Chest", "Kakariko Village"],
     "itemId": "Orange_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Eldin Province/Renados Letter.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Renados Letter.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "(canCompleteTempleofTime or (Setting.iliaQuest not_equal Vanilla)) and CanCompleteEldinTwilight",
-    "glitchedRequirements": "(canCompleteTempleofTime or (Setting.iliaQuest not_equal Vanilla)) and CanCompleteEldinTwilight",
+    "requirements": "(CanCompleteTempleofTime or (Setting.iliaQuest not_equal Vanilla)) and CanCompleteEldinTwilight",
+    "glitchedRequirements": "(CanCompleteTempleofTime or (Setting.iliaQuest not_equal Vanilla)) and CanCompleteEldinTwilight",
     "checkCategory": ["Overworld", "Quest", "Kakariko Village"],
     "itemId": "Renados_Letter"
 }

--- a/Generator/World/Checks/Overworld/Eldin Province/Talo Sharpshooting.jsonc
+++ b/Generator/World/Checks/Overworld/Eldin Province/Talo Sharpshooting.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canCompleteGoronMines and (Progressive_Bow, 1) and CanChangeTime and CanCompleteEldinTwilight",
-    "glitchedRequirements": "canCompleteGoronMines and (Progressive_Bow, 1) and CanChangeTime and CanCompleteEldinTwilight",
+    "requirements": "CanCompleteGoronMines and (Progressive_Bow, 1) and CanChangeTime and CanCompleteEldinTwilight",
+    "glitchedRequirements": "CanCompleteGoronMines and (Progressive_Bow, 1) and CanChangeTime and CanCompleteEldinTwilight",
     "checkCategory": ["Overworld", "Npc", "Kakariko Village", "ARC"],
     "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Overworld/Faron Province/Faron Mist North Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Faron Province/Faron Mist North Chest.jsonc
@@ -1,6 +1,6 @@
 {
-  "requirements": "Lantern and canCompletePrologue and (CanCompleteFaronTwilight or Shadow_Crystal)",
-  "glitchedRequirements": "((Lantern and (CanCompleteFaronTwilight or Shadow_Crystal)) or CanDoMapGlitch) and canCompletePrologue",
+  "requirements": "Lantern and CanCompletePrologue and (CanCompleteFaronTwilight or Shadow_Crystal)",
+  "glitchedRequirements": "((Lantern and (CanCompleteFaronTwilight or Shadow_Crystal)) or CanDoMapGlitch) and CanCompletePrologue",
   "checkCategory": [ "Overworld", "Chest", "Faron Woods", "DZX" ],
   "itemId": "Yellow_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Faron Province/Faron Mist Poe.jsonc
+++ b/Generator/World/Checks/Overworld/Faron Province/Faron Mist Poe.jsonc
@@ -1,5 +1,5 @@
 {
-  "requirements": "Shadow_Crystal and canCompletePrologue and CanCompleteFaronTwilight",
+  "requirements": "Shadow_Crystal and CanCompletePrologue and CanCompleteFaronTwilight",
   "glitchedRequirements": "Shadow_Crystal and CanCompleteFaronTwilight",
   "checkCategory": [ "Overworld", "Poe", "Faron Woods" ],
   "itemId": "Poe_Soul"

--- a/Generator/World/Checks/Overworld/Faron Province/Faron Mist South Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Faron Province/Faron Mist South Chest.jsonc
@@ -1,6 +1,6 @@
 {
-  "requirements": "Lantern and canCompletePrologue and (CanCompleteFaronTwilight or Shadow_Crystal)",
-  "glitchedRequirements": "((Lantern and (CanCompleteFaronTwilight or Shadow_Crystal)) or CanDoMapGlitch) and canCompletePrologue",
+  "requirements": "Lantern and CanCompletePrologue and (CanCompleteFaronTwilight or Shadow_Crystal)",
+  "glitchedRequirements": "((Lantern and (CanCompleteFaronTwilight or Shadow_Crystal)) or CanDoMapGlitch) and CanCompletePrologue",
   "checkCategory": [ "Overworld", "Chest", "Faron Woods" ],
   "itemId": "Purple_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Faron Province/Faron Mist Stump Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Faron Province/Faron Mist Stump Chest.jsonc
@@ -1,6 +1,6 @@
 {
-  "requirements": "Lantern and canCompletePrologue and (CanCompleteFaronTwilight or Shadow_Crystal)",
-  "glitchedRequirements": "((Lantern and CanCompleteFaronTwilight) or Shadow_Crystal) and canCompletePrologue",
+  "requirements": "Lantern and CanCompletePrologue and (CanCompleteFaronTwilight or Shadow_Crystal)",
+  "glitchedRequirements": "((Lantern and CanCompleteFaronTwilight) or Shadow_Crystal) and CanCompletePrologue",
   "checkCategory": [ "Overworld", "Chest", "Faron Woods" ],
   "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Faron Province/Faron Woods Coro Boulder Rupee 1.jsonc
+++ b/Generator/World/Checks/Overworld/Faron Province/Faron Woods Coro Boulder Rupee 1.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": [ "Overworld", "Faron Woods", "Rupee - Hidden" ],
     "itemId": "Green_Rupee"
   }

--- a/Generator/World/Checks/Overworld/Faron Province/Faron Woods Coro Boulder Rupee 2.jsonc
+++ b/Generator/World/Checks/Overworld/Faron Province/Faron Woods Coro Boulder Rupee 2.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": [ "Overworld", "Faron Woods", "Rupee - Hidden" ],
     "itemId": "Green_Rupee"
   }

--- a/Generator/World/Checks/Overworld/Faron Province/Faron Woods Coro Boulder Rupee 3.jsonc
+++ b/Generator/World/Checks/Overworld/Faron Province/Faron Woods Coro Boulder Rupee 3.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": [ "Overworld", "Faron Woods", "Rupee - Hidden" ],
     "itemId": "Blue_Rupee"
   }

--- a/Generator/World/Checks/Overworld/Faron Province/Faron Woods Coro Boulder Rupee 4.jsonc
+++ b/Generator/World/Checks/Overworld/Faron Province/Faron Woods Coro Boulder Rupee 4.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": [ "Overworld", "Faron Woods", "Rupee - Hidden" ],
     "itemId": "Yellow_Rupee"
   }

--- a/Generator/World/Checks/Overworld/Faron Province/Faron Woods Owl Statue Sky Character.jsonc
+++ b/Generator/World/Checks/Overworld/Faron Province/Faron Woods Owl Statue Sky Character.jsonc
@@ -1,6 +1,6 @@
 {
-  "requirements": "canClearForest and (Progressive_Dominion_Rod, 2)",
-  "glitchedRequirements": "(Progressive_Dominion_Rod, 2) and (CanDoMapGlitch or (canSmash and canClearForest))",
+  "requirements": "CanClearForest and (Progressive_Dominion_Rod, 2)",
+  "glitchedRequirements": "(Progressive_Dominion_Rod, 2) and (CanDoMapGlitch or (CanSmash and CanClearForest))",
   "checkCategory": [ "Overworld", "Faron Woods", "Sky Book" ],
   "itemId": "Progressive_Sky_Book"
 }

--- a/Generator/World/Checks/Overworld/Faron Province/Lost Woods Boulder Poe.jsonc
+++ b/Generator/World/Checks/Overworld/Faron Province/Lost Woods Boulder Poe.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "Shadow_Crystal and (CanDefeatSkullKid or (Setting.totEntrance equals Open) or (Setting.totEntrance equals OpenGrove)) and canSmash",
-    "glitchedRequirements": "Shadow_Crystal and (CanDefeatSkullKid or (Setting.totEntrance equals Open) or (Setting.totEntrance equals OpenGrove)) and canSmash",
+    "requirements": "Shadow_Crystal and (CanDefeatSkullKid or (Setting.totEntrance equals Open) or (Setting.totEntrance equals OpenGrove)) and CanSmash",
+    "glitchedRequirements": "Shadow_Crystal and (CanDefeatSkullKid or (Setting.totEntrance equals Open) or (Setting.totEntrance equals OpenGrove)) and CanSmash",
     "checkCategory": ["Overworld", "Poe", "Sacred Grove"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Overworld/Faron Province/Sacred Grove Baba Serpent Grotto Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Faron Province/Sacred Grove Baba Serpent Grotto Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "CanDefeatBabaSerpent and canKnockDownHangingBaba",
-    "glitchedRequirements": "CanDefeatBabaSerpent and (canKnockDownHangingBaba or HasSword or Shadow_Crystal or Slingshot or Ball_and_Chain or hasBombs)",
+    "requirements": "CanDefeatBabaSerpent and CanKnockDownHangingBaba",
+    "glitchedRequirements": "CanDefeatBabaSerpent and (CanKnockDownHangingBaba or HasSword or Shadow_Crystal or Slingshot or Ball_and_Chain or hasBombs)",
     "checkCategory": ["Overworld", "Chest", "Sacred Grove"],
     "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Overworld/Faron Province/Sacred Grove Baba Serpent Grotto Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Faron Province/Sacred Grove Baba Serpent Grotto Chest.jsonc
@@ -1,6 +1,6 @@
 {
     "requirements": "CanDefeatBabaSerpent and CanKnockDownHangingBaba",
-    "glitchedRequirements": "CanDefeatBabaSerpent and (CanKnockDownHangingBaba or HasSword or Shadow_Crystal or Slingshot or Ball_and_Chain or hasBombs)",
+    "glitchedRequirements": "CanDefeatBabaSerpent and (CanKnockDownHangingBaba or HasSword or Shadow_Crystal or Slingshot or Ball_and_Chain or HasBombs)",
     "checkCategory": ["Overworld", "Chest", "Sacred Grove"],
     "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Overworld/Gerudo Desert/Gerudo Desert Rock Grotto First Poe.jsonc
+++ b/Generator/World/Checks/Overworld/Gerudo Desert/Gerudo Desert Rock Grotto First Poe.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "Shadow_Crystal and canSmash",
-    "glitchedRequirements": "Shadow_Crystal and canSmash",
+    "requirements": "Shadow_Crystal and CanSmash",
+    "glitchedRequirements": "Shadow_Crystal and CanSmash",
     "checkCategory": ["Overworld", "Poe", "Gerudo Desert"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Overworld/Gerudo Desert/Gerudo Desert Rock Grotto Lantern Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Gerudo Desert/Gerudo Desert Rock Grotto Lantern Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash and Lantern",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash and Lantern",
     "checkCategory": ["Overworld", "Chest", "Gerudo Desert"],
     "itemId": "Orange_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Gerudo Desert/Gerudo Desert Rock Grotto Second Poe.jsonc
+++ b/Generator/World/Checks/Overworld/Gerudo Desert/Gerudo Desert Rock Grotto Second Poe.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "Shadow_Crystal and canSmash",
-    "glitchedRequirements": "Shadow_Crystal and canSmash",
+    "requirements": "Shadow_Crystal and CanSmash",
+    "glitchedRequirements": "Shadow_Crystal and CanSmash",
     "checkCategory": ["Overworld", "Poe", "Gerudo Desert"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Overworld/Gerudo Desert/Gerudo Desert West Canyon Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Gerudo Desert/Gerudo Desert West Canyon Chest.jsonc
@@ -1,6 +1,6 @@
 {
     "requirements": "(Progressive_Clawshot, 1)",
-    "glitchedRequirements": "(Progressive_Clawshot, 1) or CanDoLJA or (Shadow_Crystal and hasBombs)",
+    "glitchedRequirements": "(Progressive_Clawshot, 1) or CanDoLJA or (Shadow_Crystal and HasBombs)",
     "checkCategory": ["Overworld", "Chest", "Gerudo Desert"],
     "itemId": "Purple_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Eighth Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Eighth Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Bomblings_5"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Eleventh Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Eleventh Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Bomblings_10"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave End Lantern Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave End Lantern Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash and Lantern",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash and Lantern",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Fifth Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Fifth Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Final Poe.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Final Poe.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "Shadow_Crystal and canSmash and Lantern",
-    "glitchedRequirements": "Shadow_Crystal and canSmash",
+    "requirements": "Shadow_Crystal and CanSmash and Lantern",
+    "glitchedRequirements": "Shadow_Crystal and CanSmash",
     "checkCategory": ["Overworld", "Poe", "Lake Lantern Cave"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave First Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave First Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Bomblings_5"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave First Poe.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave First Poe.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "Shadow_Crystal and canSmash and Lantern",
-    "glitchedRequirements": "Shadow_Crystal and canSmash",
+    "requirements": "Shadow_Crystal and CanSmash and Lantern",
+    "glitchedRequirements": "Shadow_Crystal and CanSmash",
     "checkCategory": ["Overworld", "Poe", "Lake Lantern Cave"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Fourteenth Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Fourteenth Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Orange_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Fourth Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Fourth Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Arrows_10"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Ninth Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Ninth Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Arrows_10"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Second Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Second Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Yellow_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Second Poe.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Second Poe.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "Shadow_Crystal and canSmash and Lantern",
-    "glitchedRequirements": "Shadow_Crystal and canSmash",
+    "requirements": "Shadow_Crystal and CanSmash and Lantern",
+    "glitchedRequirements": "Shadow_Crystal and CanSmash",
     "checkCategory": ["Overworld", "Poe", "Lake Lantern Cave"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Seventh Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Seventh Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Sixth Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Sixth Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash and Lantern",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash and Lantern",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Orange_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Tenth Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Tenth Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Purple_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Third Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Third Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Thirteenth Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Thirteenth Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Seeds_50"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Twelfth Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Lantern Cave Twelfth Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canSmash and Lantern",
-    "glitchedRequirements": "canSmash",
+    "requirements": "CanSmash and Lantern",
+    "glitchedRequirements": "CanSmash",
     "checkCategory": ["Overworld", "Chest", "Lake Lantern Cave"],
     "itemId": "Purple_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lanayru Field Skulltula Grotto Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lanayru Field Skulltula Grotto Chest.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "CanDefeatSkulltula and Lantern and canBreakWoodenDoor",
-    "glitchedRequirements": "Lantern and canBreakWoodenDoor",
+    "requirements": "CanDefeatSkulltula and Lantern and CanBreakWoodenDoor",
+    "glitchedRequirements": "Lantern and CanBreakWoodenDoor",
     "checkCategory": ["Overworld", "Chest", "Hyrule Field - Lanayru Province"],
     "itemId": "Orange_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lanayru Field Spinner Track Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lanayru Field Spinner Track Chest.jsonc
@@ -1,6 +1,6 @@
 {
     "requirements": "Spinner",
-    "glitchedRequirements": "CanDoMapGlitch or (canSmash and Spinner)",
+    "glitchedRequirements": "CanDoMapGlitch or (CanSmash and Spinner)",
     "checkCategory": ["Overworld", "Chest", "Hyrule Field - Lanayru Province"],
     "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Outside South Castle Town Double Clawshot Chasm Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Outside South Castle Town Double Clawshot Chasm Chest.jsonc
@@ -1,6 +1,6 @@
 {
     "requirements": "(Progressive_Clawshot, 2)",
-    "glitchedRequirements": "(Progressive_Clawshot, 2) or (HasSword and (((Setting.damageMagnification equals Vanilla) or (Setting.damageMagnification equals Double)) or CanUseBottledFairy))  or hasBombs or Spinner or Shadow_Crystal",
+    "glitchedRequirements": "(Progressive_Clawshot, 2) or (HasSword and (((Setting.damageMagnification equals Vanilla) or (Setting.damageMagnification equals Double)) or CanUseBottledFairy))  or HasBombs or Spinner or Shadow_Crystal",
     "checkCategory": ["Overworld", "Chest", "Hyrule Field - Lanayru Province"],
     "itemId": "Orange_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Outside South Castle Town Fountain Chest.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Outside South Castle Town Fountain Chest.jsonc
@@ -1,6 +1,6 @@
 {
     "requirements": "Spinner and (Progressive_Clawshot, 1)",
-    "glitchedRequirements": "(Spinner and (Progressive_Clawshot, 1)) or (CanDoMapGlitch and HasBottle) or CanDoMoonBoots or CanDoBSMoonBoots or CanDoLJA or (HasSword and ((Progressive_Hidden_Skill, 3) or hasBombs))",
+    "glitchedRequirements": "(Spinner and (Progressive_Clawshot, 1)) or (CanDoMapGlitch and HasBottle) or CanDoMoonBoots or CanDoBSMoonBoots or CanDoLJA or (HasSword and ((Progressive_Hidden_Skill, 3) or HasBombs))",
     "checkCategory": ["Overworld", "Chest", "Hyrule Field - Lanayru Province"],
     "itemId": "Orange_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Lanayru Province/Zoras Domain Chest Behind Waterfall.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Zoras Domain Chest Behind Waterfall.jsonc
@@ -1,6 +1,6 @@
 {
     "requirements": "Shadow_Crystal",
-    "glitchedRequirements": "Shadow_Crystal or CanDoBSMoonBoots or Spinner or (hasBombs and HasSword) or CanDoLJA",
+    "glitchedRequirements": "Shadow_Crystal or CanDoBSMoonBoots or Spinner or (HasBombs and HasSword) or CanDoLJA",
     "checkCategory": ["Overworld", "Chest", "Zoras Domain"],
     "itemId": "Red_Rupee"
 }

--- a/Generator/World/Checks/Overworld/Ordona Province/Herding Goats Reward.jsonc
+++ b/Generator/World/Checks/Overworld/Ordona Province/Herding Goats Reward.jsonc
@@ -1,6 +1,6 @@
 {
-  "requirements": "canCompletePrologue and CanChangeTime and CanCompleteGoats1",
-  "glitchedRequirements": "canCompletePrologue and CanChangeTime and CanCompleteGoats1",
+  "requirements": "CanCompletePrologue and CanChangeTime and CanCompleteGoats1",
+  "glitchedRequirements": "CanCompletePrologue and CanChangeTime and CanCompleteGoats1",
   "checkCategory": [ "Overworld", "Npc", "Ordona Province" ],
   "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Checks/Overworld/Ordona Province/Ordon Shield.jsonc
+++ b/Generator/World/Checks/Overworld/Ordona Province/Ordon Shield.jsonc
@@ -1,6 +1,6 @@
 {
-  "requirements": "(((Setting.faronTwilightCleared equals False) and canCompletePrologue) or ((Setting.faronTwilightCleared equals True) and Shadow_Crystal)) and ((Setting.bonksDoDamage equals False) or ((Setting.bonksDoDamage equals True) and ((Setting.damageMagnification not_equal OHKO) or CanUseBottledFairies)))",
-  "glitchedRequirements": "(((Setting.faronTwilightCleared equals False) and canCompletePrologue) or ((Setting.faronTwilightCleared equals True) and Shadow_Crystal)) and ((Setting.bonksDoDamage equals False) or ((Setting.bonksDoDamage equals True) and ((Setting.damageMagnification not_equal OHKO) or CanUseBottledFairies)))",
+  "requirements": "(((Setting.faronTwilightCleared equals False) and CanCompletePrologue) or ((Setting.faronTwilightCleared equals True) and Shadow_Crystal)) and ((Setting.bonksDoDamage equals False) or ((Setting.bonksDoDamage equals True) and ((Setting.damageMagnification not_equal OHKO) or CanUseBottledFairies)))",
+  "glitchedRequirements": "(((Setting.faronTwilightCleared equals False) and CanCompletePrologue) or ((Setting.faronTwilightCleared equals True) and Shadow_Crystal)) and ((Setting.bonksDoDamage equals False) or ((Setting.bonksDoDamage equals True) and ((Setting.damageMagnification not_equal OHKO) or CanUseBottledFairies)))",
   "checkCategory": [ "Overworld", "Ordona Province" ],
   "itemId": "Ordon_Shield"
 }

--- a/Generator/World/Checks/Overworld/Ordona Province/Ordon Spring Golden Wolf.jsonc
+++ b/Generator/World/Checks/Overworld/Ordona Province/Ordon Spring Golden Wolf.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "Shadow_Crystal and Room.Death_Mountain_Trail and canCompletePrologue and CanCompleteFaronTwilight",
-    "glitchedRequirements": "Shadow_Crystal and Room.Death_Mountain_Trail and canCompletePrologue and CanCompleteFaronTwilight",
+    "requirements": "Shadow_Crystal and Room.Death_Mountain_Trail and CanCompletePrologue and CanCompleteFaronTwilight",
+    "glitchedRequirements": "Shadow_Crystal and Room.Death_Mountain_Trail and CanCompletePrologue and CanCompleteFaronTwilight",
     "checkCategory": ["Overworld", "Hidden Skill", "Ordona Province"],
     "itemId": "Progressive_Hidden_Skill"
 }

--- a/Generator/World/Checks/Overworld/Ordona Province/Ordon Sword.jsonc
+++ b/Generator/World/Checks/Overworld/Ordona Province/Ordon Sword.jsonc
@@ -1,6 +1,6 @@
 {
-  "requirements": "canCompletePrologue or (Setting.faronTwilightCleared equals True)",
-  "glitchedRequirements": "canCompletePrologue or (Setting.faronTwilightCleared equals True)",
+  "requirements": "CanCompletePrologue or (Setting.faronTwilightCleared equals True)",
+  "glitchedRequirements": "CanCompletePrologue or (Setting.faronTwilightCleared equals True)",
   "checkCategory": [ "Overworld", "Ordona Province"],
   "itemId": "Progressive_Sword"
 }

--- a/Generator/World/Checks/Overworld/Snowpeak Province/Snowboard Racing Prize.jsonc
+++ b/Generator/World/Checks/Overworld/Snowpeak Province/Snowboard Racing Prize.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "canCompleteSnowpeakRuins and CanDefeatShadowBeast",
-    "glitchedRequirements": "canCompleteSnowpeakRuins",
+    "requirements": "CanCompleteSnowpeakRuins and CanDefeatShadowBeast",
+    "glitchedRequirements": "CanCompleteSnowpeakRuins",
     "checkCategory": ["Overworld", "Npc", "Snowpeak Province"],
     "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Rooms/Dungeons/Forest Temple.jsonc
+++ b/Generator/World/Rooms/Dungeons/Forest Temple.jsonc
@@ -129,7 +129,7 @@
           {
             "ConnectedArea": "Ook",
             "Requirements": "Boomerang",
-            "GlitchedRequirements": "Boomerang or Shadow_Crystal or HasSword or hasBombs"
+            "GlitchedRequirements": "Boomerang or Shadow_Crystal or HasSword or HasBombs"
           }
         ],
         "Checks": 

--- a/Generator/World/Rooms/Dungeons/Forest Temple.jsonc
+++ b/Generator/World/Rooms/Dungeons/Forest Temple.jsonc
@@ -51,8 +51,8 @@
           },
           {
             "ConnectedArea": "Forest Temple Lobby",
-            "Requirements": "CanDefeatWalltula and CanDefeatBokoblin and canBreakMonkeyCage",
-            "GlitchedRequirements": "CanDefeatWalltula and CanDefeatBokoblin and canBreakMonkeyCage"
+            "Requirements": "CanDefeatWalltula and CanDefeatBokoblin and CanBreakMonkeyCage",
+            "GlitchedRequirements": "CanDefeatWalltula and CanDefeatBokoblin and CanBreakMonkeyCage"
           }
         ],
         "Checks": 
@@ -77,13 +77,13 @@
             },
             {
               "ConnectedArea": "Forest Temple West Wing",
-                "Requirements": "canBurnWebs and (((Forest_Temple_Small_Key, 2) and CanDefeatBokoblin) or (Progressive_Clawshot, 1))",
-                "GlitchedRequirements": "canBurnWebs and (((Forest_Temple_Small_Key, 2) and CanDefeatBokoblin) or (Progressive_Clawshot, 1) or CanDoLJA)"
+                "Requirements": "CanBurnWebs and (((Forest_Temple_Small_Key, 2) and CanDefeatBokoblin) or (Progressive_Clawshot, 1))",
+                "GlitchedRequirements": "CanBurnWebs and (((Forest_Temple_Small_Key, 2) and CanDefeatBokoblin) or (Progressive_Clawshot, 1) or CanDoLJA)"
             },
             {
               "ConnectedArea": "Ook",
-                "Requirements": "Lantern and CanDefeatWalltula and CanDefeatBokoblin and canBreakMonkeyCage and (Forest_Temple_Small_Key, 4)",
-                "GlitchedRequirements": "(Room.Forest_Temple_West_Wing and CanDoLJA) or (Lantern and CanDefeatBombling and CanDefeatWalltula and CanDefeatBigBaba and CanDefeatBokoblin and canBreakMonkeyCage and (Forest_Temple_Small_Key, 4))"
+                "Requirements": "Lantern and CanDefeatWalltula and CanDefeatBokoblin and CanBreakMonkeyCage and (Forest_Temple_Small_Key, 4)",
+                "GlitchedRequirements": "(Room.Forest_Temple_West_Wing and CanDoLJA) or (Lantern and CanDefeatBombling and CanDefeatWalltula and CanDefeatBigBaba and CanDefeatBokoblin and CanBreakMonkeyCage and (Forest_Temple_Small_Key, 4))"
             }
         ], 
         "Checks": 
@@ -105,8 +105,8 @@
             },
             {
               "ConnectedArea": "Forest Temple Boss Room",
-              "Requirements": "Forest_Temple_Big_Key and Boomerang and (canFreeAllMonkeys or (Progressive_Clawshot, 1))",
-              "GlitchedRequirements": "Forest_Temple_Big_Key and (CanDoLJA or (Boomerang and (canFreeAllMonkeys or (Progressive_Clawshot, 1))))"
+              "Requirements": "Forest_Temple_Big_Key and Boomerang and (CanFreeAllMonkeys or (Progressive_Clawshot, 1))",
+              "GlitchedRequirements": "Forest_Temple_Big_Key and (CanDoLJA or (Boomerang and (CanFreeAllMonkeys or (Progressive_Clawshot, 1))))"
             }
         ],
         "Checks": 

--- a/Generator/World/Rooms/Dungeons/Goron Mines.jsonc
+++ b/Generator/World/Rooms/Dungeons/Goron Mines.jsonc
@@ -51,8 +51,8 @@
             },
             {
                 "ConnectedArea": "Goron Mines Magnet Room",
-                "Requirements": "Iron_Boots and canBreakWoodenDoor",
-                "GlitchedRequirements": "(Iron_Boots or Shadow_Crystal) and (canBreakWoodenDoor or CanDoBSMoonBoots)"
+                "Requirements": "Iron_Boots and CanBreakWoodenDoor",
+                "GlitchedRequirements": "(Iron_Boots or Shadow_Crystal) and (CanBreakWoodenDoor or CanDoBSMoonBoots)"
             }
         ],
         "Checks":

--- a/Generator/World/Rooms/Dungeons/Goron Mines.jsonc
+++ b/Generator/World/Rooms/Dungeons/Goron Mines.jsonc
@@ -29,7 +29,7 @@
             {
               "ConnectedArea": "Goron Mines North Wing",
               "Requirements": "((Iron_Boots and HasSword) or (Progressive_Bow, 1)) and (Goron_Mines_Small_Key, 2)",
-              "GlitchedRequirements": "(Goron_Mines_Small_Key, 2) and ((Progressive_Bow, 1) or (Iron_Boots and HasSword) or ((CanDoLJA or (HasSword and hasBombs)) and ((Progressive_Clawshot, 1) or Ball_and_Chain or hasBombs)))"
+              "GlitchedRequirements": "(Goron_Mines_Small_Key, 2) and ((Progressive_Bow, 1) or (Iron_Boots and HasSword) or ((CanDoLJA or (HasSword and HasBombs)) and ((Progressive_Clawshot, 1) or Ball_and_Chain or HasBombs)))"
             }
         ],
         "Checks": 

--- a/Generator/World/Rooms/Dungeons/Hyrule Castle.jsonc
+++ b/Generator/World/Rooms/Dungeons/Hyrule Castle.jsonc
@@ -128,8 +128,8 @@
             },
             {
                 "ConnectedArea": "Hyrule Castle After Double Darknuts",
-                "Requirements": "canKnockDownHCPainting and CanDefeatLizalfos and CanDefeatDarknut",
-                "GlitchedRequirements": "canKnockDownHCPainting and CanDefeatLizalfos and CanDefeatDarknut"
+                "Requirements": "CanKnockDownHCPainting and CanDefeatLizalfos and CanDefeatDarknut",
+                "GlitchedRequirements": "CanKnockDownHCPainting and CanDefeatLizalfos and CanDefeatDarknut"
             }
         ],
         "Checks": ["Hyrule Castle Lantern Staircase Chest"],
@@ -192,8 +192,8 @@
             },
             {
                 "ConnectedArea": "Hyrule Castle After Double Darknuts",
-                "Requirements": "CanDefeatDarknut and CanDefeatLizalfos and canKnockDownHCPainting",
-                "GlitchedRequirements": "CanDefeatDarknut and CanDefeatLizalfos and canKnockDownHCPainting"
+                "Requirements": "CanDefeatDarknut and CanDefeatLizalfos and CanKnockDownHCPainting",
+                "GlitchedRequirements": "CanDefeatDarknut and CanDefeatLizalfos and CanKnockDownHCPainting"
             },
             {
                 "ConnectedArea": "Hyrule Castle Tower Climb",

--- a/Generator/World/Rooms/Dungeons/Lakebed Temple.jsonc
+++ b/Generator/World/Rooms/Dungeons/Lakebed Temple.jsonc
@@ -38,12 +38,12 @@
             },
             {
               "ConnectedArea": "Lakebed Temple West Wing",
-              "Requirements": "(Lakebed_Temple_Small_Key, 3) and canSmash and (Progressive_Clawshot, 1)",
-              "GlitchedRequirements": "(Lakebed_Temple_Small_Key, 3) and canSmash and (Progressive_Clawshot, 1)"
+              "Requirements": "(Lakebed_Temple_Small_Key, 3) and CanSmash and (Progressive_Clawshot, 1)",
+              "GlitchedRequirements": "(Lakebed_Temple_Small_Key, 3) and CanSmash and (Progressive_Clawshot, 1)"
             },
             {
               "ConnectedArea": "Lakebed Temple Boss Room",
-              "Requirements": "(Lakebed_Temple_Small_Key, 3) and canLaunchBombs and (Progressive_Clawshot, 1) and Lakebed_Temple_Big_Key",
+              "Requirements": "(Lakebed_Temple_Small_Key, 3) and CanLaunchBombs and (Progressive_Clawshot, 1) and Lakebed_Temple_Big_Key",
               "GlitchedRequirements": "((Progressive_Clawshot, 1) and ((Progressive_Sword, 1) or Lakebed_Temple_Big_Key)) or CanDoLJA"
             }
           ],
@@ -88,8 +88,8 @@
         },
         {
             "ConnectedArea": "Lakebed Temple East Wing First Floor",
-            "Requirements": "canLaunchBombs or (Progressive_Clawshot, 1)",
-            "GlitchedRequirements": "canLaunchBombs or (Progressive_Clawshot, 1)"
+            "Requirements": "CanLaunchBombs or (Progressive_Clawshot, 1)",
+            "GlitchedRequirements": "CanLaunchBombs or (Progressive_Clawshot, 1)"
         }
         ],
         "Checks": 
@@ -112,8 +112,8 @@
           },
           {
             "ConnectedArea": "Lakebed Temple Central Room",
-            "Requirements": "canLaunchBombs and (Zora_Armor or CanDoAirRefill)",
-            "GlitchedRequirements": "(Zora_Armor or CanDoAirRefill) and (canLaunchBombs or CanDoLJA or CanDoJSMoonBoots)"
+            "Requirements": "CanLaunchBombs and (Zora_Armor or CanDoAirRefill)",
+            "GlitchedRequirements": "(Zora_Armor or CanDoAirRefill) and (CanLaunchBombs or CanDoLJA or CanDoJSMoonBoots)"
           }
         ],
         "Checks": 

--- a/Generator/World/Rooms/Dungeons/Snowpeak Ruins.jsonc
+++ b/Generator/World/Rooms/Dungeons/Snowpeak Ruins.jsonc
@@ -346,16 +346,16 @@
           },
           {
             "ConnectedArea": "Snowpeak Ruins Chapel",
-            "Requirements": "(Snowpeak_Ruins_Small_Key, 4) and Snowpeak_Ruins_Ordon_Goat_Cheese and Ball_and_Chain and hasBombs",
+            "Requirements": "(Snowpeak_Ruins_Small_Key, 4) and Snowpeak_Ruins_Ordon_Goat_Cheese and Ball_and_Chain and HasBombs",
             // Freezard Ladder Cancel
             "GlitchedRequirements": "(Snowpeak_Ruins_Small_Key, 4) or Snowpeak_Ruins_Ordon_Goat_Cheese"
           },
           {
             "ConnectedArea": "Snowpeak Ruins Darkhammer Room",
             //Don't require gate to be unlocked for cannonballs if we have Cheese since we can get to the other side by going through Yeta's room.
-            "Requirements": "Ball_and_Chain or (((Snowpeak_Ruins_Small_Key, 2) or Snowpeak_Ruins_Ordon_Goat_Cheese) and hasBombs)",
+            "Requirements": "Ball_and_Chain or (((Snowpeak_Ruins_Small_Key, 2) or Snowpeak_Ruins_Ordon_Goat_Cheese) and HasBombs)",
             // We can also just wolf clip in.
-            "GlitchedRequirements": "Ball_and_Chain or (((Snowpeak_Ruins_Small_Key, 4) or Snowpeak_Ruins_Ordon_Goat_Cheese) and hasBombs) or (Shadow_Crystal and (Setting.damageMagnification not_equal OHKO))"
+            "GlitchedRequirements": "Ball_and_Chain or (((Snowpeak_Ruins_Small_Key, 4) or Snowpeak_Ruins_Ordon_Goat_Cheese) and HasBombs) or (Shadow_Crystal and (Setting.damageMagnification not_equal OHKO))"
           }
         ],
         "Checks": 

--- a/Generator/World/Rooms/Dungeons/Snowpeak Ruins.jsonc
+++ b/Generator/World/Rooms/Dungeons/Snowpeak Ruins.jsonc
@@ -133,7 +133,7 @@
             "ConnectedArea": "Snowpeak Ruins Boss Room",
             "Requirements": "Snowpeak_Ruins_Bedroom_Key",
             "GlitchedRequirements": "Snowpeak_Ruins_Bedroom_Key"
-          },
+          }
         ],
         "Checks": 
         [
@@ -313,8 +313,8 @@
           },
           {
             "ConnectedArea": "Snowpeak Ruins Wooden Beam Room",
-            "Requirements": "canSmash",
-            "GlitchedRequirements": "canSmash"
+            "Requirements": "CanSmash",
+            "GlitchedRequirements": "CanSmash"
           }
         ], 
         "Checks": 

--- a/Generator/World/Rooms/Dungeons/Temple of Time.jsonc
+++ b/Generator/World/Rooms/Dungeons/Temple of Time.jsonc
@@ -72,8 +72,8 @@
           },
           {
             "ConnectedArea": "Temple of Time Central Mechanical Platform",
-            "Requirements": "hasRangedItem and CanDefeatYoungGohma and CanDefeatLizalfos",
-            "GlitchedRequirements": "hasRangedItem and CanDefeatYoungGohma and CanDefeatLizalfos"
+            "Requirements": "HasRangedItem and CanDefeatYoungGohma and CanDefeatLizalfos",
+            "GlitchedRequirements": "HasRangedItem and CanDefeatYoungGohma and CanDefeatLizalfos"
           }
         ],
         "Checks": 

--- a/Generator/World/Rooms/Overworld/Eldin Province/Death Mountain.jsonc
+++ b/Generator/World/Rooms/Overworld/Eldin Province/Death Mountain.jsonc
@@ -10,8 +10,8 @@
       },
       {
         "ConnectedArea": "Death Mountain Trail",
-        "Requirements": "Iron_Boots or canCompleteGoronMines",
-        "GlitchedRequirements": "Iron_Boots or canCompleteGoronMines"
+        "Requirements": "Iron_Boots or CanCompleteGoronMines",
+        "GlitchedRequirements": "Iron_Boots or CanCompleteGoronMines"
       }
     ],
     "Checks": [""],
@@ -27,7 +27,7 @@
         "GlitchedRequirements": "true"
       },
       {
-        "ConnectedArea": "Death Mountain Volcano",
+        "ConnectedArea": "Death Mountain VolCano",
         "Requirements": "true",
         "GlitchedRequirements": "true"
       }
@@ -40,7 +40,7 @@
     "Region": "Death Mountain"
   },
   {
-    "RoomName": "Death Mountain Volcano",
+    "RoomName": "Death Mountain VolCano",
     "Exits":
     [
       {
@@ -50,8 +50,8 @@
       },
       {
         "ConnectedArea": "Death Mountain Outside Sumo Hall",
-        "Requirements": "Iron_Boots and (CanDefeatGoron or canCompleteGoronMines) and CanCompleteEldinTwilight",
-        "GlitchedRequirements": "Iron_Boots and (CanDefeatGoron or canCompleteGoronMines) and CanCompleteEldinTwilight"
+        "Requirements": "Iron_Boots and (CanDefeatGoron or CanCompleteGoronMines) and CanCompleteEldinTwilight",
+        "GlitchedRequirements": "Iron_Boots and (CanDefeatGoron or CanCompleteGoronMines) and CanCompleteEldinTwilight"
       },
       {
         "ConnectedArea": "Death Mountain Elevator Lower",
@@ -76,7 +76,7 @@
     "Exits":
     [
       {
-        "ConnectedArea": "Death Mountain Volcano",
+        "ConnectedArea": "Death Mountain VolCano",
         "Requirements": "true",
         "GlitchedRequirements": "true"
       },
@@ -94,7 +94,7 @@
     "Exits":
     [
       {
-        "ConnectedArea": "Death Mountain Volcano",
+        "ConnectedArea": "Death Mountain VolCano",
         "Requirements": "true",
         "GlitchedRequirements": "true"
       },
@@ -112,7 +112,7 @@
     "Exits":
     [
       {
-        "ConnectedArea": "Death Mountain Volcano",
+        "ConnectedArea": "Death Mountain VolCano",
         "Requirements": "true",
         "GlitchedRequirements": "true"
       },

--- a/Generator/World/Rooms/Overworld/Eldin Province/Hyrule Field - Eldin.jsonc
+++ b/Generator/World/Rooms/Overworld/Eldin Province/Hyrule Field - Eldin.jsonc
@@ -5,8 +5,8 @@
     [
       {
         "ConnectedArea": "Kakariko Gorge Cave Entrance",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash"
       },
       {
         "ConnectedArea": "Kakariko Gorge Behind Gate",
@@ -20,8 +20,8 @@
       },
       {
         "ConnectedArea": "Eldin Field",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash"
       },
       {
         "ConnectedArea": "Kakariko Gorge Keese Grotto",
@@ -48,8 +48,8 @@
     [
       {
         "ConnectedArea": "Kakariko Gorge",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash"
       },
       {
         "ConnectedArea": "Eldin Lantern Cave",
@@ -133,8 +133,8 @@
       },
       {
         "ConnectedArea": "Kakariko Gorge",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash"
       },
       {
         "ConnectedArea": "Kakariko Village Behind Gate",
@@ -143,8 +143,8 @@
       },
       {
         "ConnectedArea": "North Eldin Field",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash or (Shadow_Crystal and CanCompleteEldinTwilight)"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash or (Shadow_Crystal and CanCompleteEldinTwilight)"
       },
       {
         "ConnectedArea": "Eldin Field Bomskit Grotto",
@@ -232,8 +232,8 @@
     [
       {
         "ConnectedArea": "Eldin Field",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash or (CanDoMapGlitch and CanCompleteEldinTwilight and (CanCompleteLanayruTwilight or Item.Horse_Call))"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash or (CanDoMapGlitch and CanCompleteEldinTwilight and (CanCompleteLanayruTwilight or Item.Horse_Call))"
       },
       {
         "ConnectedArea": "Eldin Field Outside Hidden Village",

--- a/Generator/World/Rooms/Overworld/Eldin Province/Hyrule Field - Eldin.jsonc
+++ b/Generator/World/Rooms/Overworld/Eldin Province/Hyrule Field - Eldin.jsonc
@@ -233,7 +233,7 @@
       {
         "ConnectedArea": "Eldin Field",
         "Requirements": "CanSmash",
-        "GlitchedRequirements": "CanSmash or (CanDoMapGlitch and CanCompleteEldinTwilight and (CanCompleteLanayruTwilight or Item.Horse_Call))"
+        "GlitchedRequirements": "CanSmash or (CanDoMapGlitch and CanCompleteEldinTwilight and (CanCompleteLanayruTwilight or Horse_Call))"
       },
       {
         "ConnectedArea": "Eldin Field Outside Hidden Village",

--- a/Generator/World/Rooms/Overworld/Eldin Province/Kakariko Village.jsonc
+++ b/Generator/World/Rooms/Overworld/Eldin Province/Kakariko Village.jsonc
@@ -554,7 +554,7 @@
       {
         "ConnectedArea": "Lake Hylia",
         "Requirements": "Gate_Keys and (Iron_Boots or Zora_Armor) and CanUseWaterBombs and CanCompleteEldinTwilight",
-        "GlitchedRequirements": "(HasHeavyMod and CanUseWaterBombs and Gate_Keys and CanCompleteEldinTwilight) or ((HasHeavyMod or Zora_Armor) and ((hasBombs and (HasSword or Spinner)) or CanDoLJA or CanDoMoonBoots))"
+        "GlitchedRequirements": "(HasHeavyMod and CanUseWaterBombs and Gate_Keys and CanCompleteEldinTwilight) or ((HasHeavyMod or Zora_Armor) and ((HasBombs and (HasSword or Spinner)) or CanDoLJA or CanDoMoonBoots))"
       }
     ],
     "Checks":

--- a/Generator/World/Rooms/Overworld/Eldin Province/Kakariko Village.jsonc
+++ b/Generator/World/Rooms/Overworld/Eldin Province/Kakariko Village.jsonc
@@ -5,8 +5,8 @@
     [
       {
         "ConnectedArea": "Upper Kakariko Village",
-        "Requirements": "((canCompleteGoronMines and CanChangeTime) or canSmash) and CanCompleteEldinTwilight",
-        "GlitchedRequirements": "((canCompleteGoronMines and CanChangeTime) or canSmash) and CanCompleteEldinTwilight"
+        "Requirements": "((CanCompleteGoronMines and CanChangeTime) or CanSmash) and CanCompleteEldinTwilight",
+        "GlitchedRequirements": "((CanCompleteGoronMines and CanChangeTime) or CanSmash) and CanCompleteEldinTwilight"
       },
       {
         "ConnectedArea": "Kakariko Village Behind Gate",
@@ -99,8 +99,8 @@
       },
       {
         "ConnectedArea": "Kakariko Top of Watchtower",
-        "Requirements": "canCompleteGoronMines and CanChangeTime and CanCompleteEldinTwilight",
-        "GlitchedRequirements": "canCompleteGoronMines and CanChangeTime and CanCompleteEldinTwilight"
+        "Requirements": "CanCompleteGoronMines and CanChangeTime and CanCompleteEldinTwilight",
+        "GlitchedRequirements": "CanCompleteGoronMines and CanChangeTime and CanCompleteEldinTwilight"
       },
       {
         "ConnectedArea": "Kakariko Barnes Bomb Shop Upper",

--- a/Generator/World/Rooms/Overworld/Faron Province/Faron Woods.jsonc
+++ b/Generator/World/Rooms/Overworld/Faron Province/Faron Woods.jsonc
@@ -416,7 +416,7 @@
       {
         "ConnectedArea": "North Faron Lost Woods Entrance",
         "Requirements": "Shadow_Crystal and CanCompleteFaronTwilight",
-        "GlitchedRequirements": "(Shadow_Crystal and CanCompleteFaronTwilight) or (hasBombs and CanDoLJA)"
+        "GlitchedRequirements": "(Shadow_Crystal and CanCompleteFaronTwilight) or (HasBombs and CanDoLJA)"
       },
       {
         "ConnectedArea": "Forest Temple Entrance",

--- a/Generator/World/Rooms/Overworld/Faron Province/Faron Woods.jsonc
+++ b/Generator/World/Rooms/Overworld/Faron Province/Faron Woods.jsonc
@@ -10,20 +10,20 @@
       },
       {
         "ConnectedArea": "South Faron Woods Owl Statue Area",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash"
       },
       {
         // Worst case scenerio, if you complete prologue then you also need to complete Faron Twilight
         "ConnectedArea": "Ordon Bridge",
-        "Requirements": "canCompletePrologue and CanCompleteFaronTwilight",
-        "GlitchedRequirements": "canCompletePrologue and CanCompleteFaronTwilight"
+        "Requirements": "CanCompletePrologue and CanCompleteFaronTwilight",
+        "GlitchedRequirements": "CanCompletePrologue and CanCompleteFaronTwilight"
       },
       {
         "ConnectedArea": "Faron Field",
-        "Requirements": "canClearForest and CanCompleteFaronTwilight and canCompletePrologue",
+        "Requirements": "CanClearForest and CanCompleteFaronTwilight and CanCompletePrologue",
         // There's no prologue requirement because worse case scenerio, you just gate clip
-        "GlitchedRequirements": "canClearForestGlitched and CanCompleteFaronTwilight"
+        "GlitchedRequirements": "CanClearForestGlitched and CanCompleteFaronTwilight"
       },
       {
         "ConnectedArea": "Faron Woods Coros House Lower",
@@ -86,13 +86,13 @@
     [
       {
         "ConnectedArea": "South Faron Woods",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash"
       },
       {
         "ConnectedArea": "South Faron Woods Above Owl Statue",
-        "Requirements": "canClearForest and (Progressive_Dominion_Rod, 2) and Shadow_Crystal and CanCompleteFaronTwilight",
-        "GlitchedRequirements": "canClearForestGlitched and (Progressive_Dominion_Rod, 2) and Shadow_Crystal and CanCompleteFaronTwilight"
+        "Requirements": "CanClearForest and (Progressive_Dominion_Rod, 2) and Shadow_Crystal and CanCompleteFaronTwilight",
+        "GlitchedRequirements": "CanClearForestGlitched and (Progressive_Dominion_Rod, 2) and Shadow_Crystal and CanCompleteFaronTwilight"
       }
     ],
     "Checks":

--- a/Generator/World/Rooms/Overworld/Faron Province/Hyrule Field - Faron.jsonc
+++ b/Generator/World/Rooms/Overworld/Faron Province/Hyrule Field - Faron.jsonc
@@ -5,7 +5,7 @@
     [
       {
         "ConnectedArea": "Faron Field Behind Boulder",
-        "Requirements": "canGetHotSpringWater and Room.Outside_Castle_Town_South",
+        "Requirements": "CanGetHotSpringWater and Room.Outside_Castle_Town_South",
         "GlitchedRequirements": "Room.Castle_Town_South and HasBottle and Room.Outside_Castle_Town_South"
       },
       {
@@ -50,8 +50,8 @@
     [
       {
         "ConnectedArea": "Faron Field",
-        "Requirements": "canGetHotSpringWater and Room.Outside_Castle_Town_South",
-        "GlitchedRequirements": "canGetHotSpringWater and HasBottle and Room.Outside_Castle_Town_South"
+        "Requirements": "CanGetHotSpringWater and Room.Outside_Castle_Town_South",
+        "GlitchedRequirements": "CanGetHotSpringWater and HasBottle and Room.Outside_Castle_Town_South"
       },
       {
          // If you enter Outside Castle Town from there while the boulder is still there, you get stuck and are forced to save-warp or portal-warp.

--- a/Generator/World/Rooms/Overworld/Faron Province/Sacred Grove.jsonc
+++ b/Generator/World/Rooms/Overworld/Faron Province/Sacred Grove.jsonc
@@ -42,8 +42,8 @@
       },
       {
         "ConnectedArea": "Lost Woods Baba Serpent Grotto",
-        "Requirements": "canSmash and Shadow_Crystal",
-        "GlitchedRequirements": "canSmash and Shadow_Crystal"
+        "Requirements": "CanSmash and Shadow_Crystal",
+        "GlitchedRequirements": "CanSmash and Shadow_Crystal"
       }
     ],
     "Checks":

--- a/Generator/World/Rooms/Overworld/Gerudo Desert/Gerudo Desert.jsonc
+++ b/Generator/World/Rooms/Overworld/Gerudo Desert/Gerudo Desert.jsonc
@@ -188,7 +188,8 @@
     [
       {
         "ConnectedArea": "Gerudo Desert Outside Bulblin Camp",
-        "Requirements": "true"
+        "Requirements": "true",
+        "GlitchedRequirements": "true"
       },
       {
         "ConnectedArea": "Outside Arbiters Grounds",

--- a/Generator/World/Rooms/Overworld/Gerudo Desert/Gerudo Desert.jsonc
+++ b/Generator/World/Rooms/Overworld/Gerudo Desert/Gerudo Desert.jsonc
@@ -259,8 +259,8 @@
       {
         // This is a temporary requirement since eventually whenever portals are actually checks, having the portal won't get rid of the Shadow beasts.
         "ConnectedArea": "Mirror Chamber Portal",
-        "Requirements": "(CanDefeatShadowBeast or (Shadow_Crystal and Mirror_Chamber_Portal)) and ((Setting.palaceRequirements equals Open) or ((Setting.palaceRequirements equals Fused_Shadows) and (Progressive_Fused_Shadow, 3)) or ((Setting.palaceRequirements equals Mirror_Shards) and (Progressive_Mirror_Shard, 4)) or ((Setting.palaceRequirements equals Vanilla) and canCompleteCityinTheSky))",
-        "GlitchedRequirements": "(CanDefeatShadowBeast or (Shadow_Crystal and Mirror_Chamber_Portal)) and ((Setting.palaceRequirements equals Open) or ((Setting.palaceRequirements equals Fused_Shadows) and (Progressive_Fused_Shadow, 3)) or ((Setting.palaceRequirements equals Mirror_Shards) and (Progressive_Mirror_Shard, 4)) or ((Setting.palaceRequirements equals Vanilla) and canCompleteCityinTheSky))"
+        "Requirements": "(CanDefeatShadowBeast or (Shadow_Crystal and Mirror_Chamber_Portal)) and ((Setting.palaceRequirements equals Open) or ((Setting.palaceRequirements equals Fused_Shadows) and (Progressive_Fused_Shadow, 3)) or ((Setting.palaceRequirements equals Mirror_Shards) and (Progressive_Mirror_Shard, 4)) or ((Setting.palaceRequirements equals Vanilla) and CanCompleteCityinTheSky))",
+        "GlitchedRequirements": "(CanDefeatShadowBeast or (Shadow_Crystal and Mirror_Chamber_Portal)) and ((Setting.palaceRequirements equals Open) or ((Setting.palaceRequirements equals Fused_Shadows) and (Progressive_Fused_Shadow, 3)) or ((Setting.palaceRequirements equals Mirror_Shards) and (Progressive_Mirror_Shard, 4)) or ((Setting.palaceRequirements equals Vanilla) and CanCompleteCityinTheSky))"
       }
     ],
     "Checks": 

--- a/Generator/World/Rooms/Overworld/Lanayru Province/Castle Town.jsonc
+++ b/Generator/World/Rooms/Overworld/Lanayru Province/Castle Town.jsonc
@@ -215,8 +215,8 @@
       },
       {
         "ConnectedArea": "Castle Town North Inside Barrier",
-        "Requirements": "(Setting.castleRequirements equals Open) or ((Setting.castleRequirements equals Vanilla) and canCompletePalaceofTwilight) or ((Setting.castleRequirements equals Fused_Shadows) and (Progressive_Fused_Shadow, 3)) or ((Setting.castleRequirements equals Mirror_Shards) and (Progressive_Mirror_Shard, 4)) or ((Setting.castleRequirements equals All_Dungeons) and canCompleteAllDungeons)",
-        "GlitchedRequirements": "(Setting.castleRequirements equals Open) or ((Setting.castleRequirements equals Vanilla) and canCompletePalaceofTwilight) or ((Setting.castleRequirements equals Fused_Shadows) and (Progressive_Fused_Shadow, 3)) or ((Setting.castleRequirements equals Mirror_Shards) and (Progressive_Mirror_Shard, 4)) or ((Setting.castleRequirements equals All_Dungeons) and canCompleteAllDungeons)"
+        "Requirements": "(Setting.castleRequirements equals Open) or ((Setting.castleRequirements equals Vanilla) and CanCompletePalaceofTwilight) or ((Setting.castleRequirements equals Fused_Shadows) and (Progressive_Fused_Shadow, 3)) or ((Setting.castleRequirements equals Mirror_Shards) and (Progressive_Mirror_Shard, 4)) or ((Setting.castleRequirements equals All_Dungeons) and CanCompleteAllDungeons)",
+        "GlitchedRequirements": "(Setting.castleRequirements equals Open) or ((Setting.castleRequirements equals Vanilla) and CanCompletePalaceofTwilight) or ((Setting.castleRequirements equals Fused_Shadows) and (Progressive_Fused_Shadow, 3)) or ((Setting.castleRequirements equals Mirror_Shards) and (Progressive_Mirror_Shard, 4)) or ((Setting.castleRequirements equals All_Dungeons) and CanCompleteAllDungeons)"
       }
     ],
     "Checks":

--- a/Generator/World/Rooms/Overworld/Lanayru Province/Hyrule Field - Lanayru.jsonc
+++ b/Generator/World/Rooms/Overworld/Lanayru Province/Hyrule Field - Lanayru.jsonc
@@ -5,18 +5,18 @@
     [
       {
         "ConnectedArea": "Lanayru Field Cave Entrance",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash"
       },
       {
         "ConnectedArea": "Lanayru Field Behind Boulder",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash or CanDoMapGlitch"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash or CanDoMapGlitch"
       },
       {
         "ConnectedArea": "Hyrule Field Near Spinner Rails",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash or (CanDoMapGlitch and CanCompleteLanayruTwilight)"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash or (CanDoMapGlitch and CanCompleteLanayruTwilight)"
       },
       {
         "ConnectedArea": "North Eldin Field",
@@ -59,8 +59,8 @@
     [
       {
         "ConnectedArea": "Lanayru Field",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash"
       },
       {
         "ConnectedArea": "Lanayru Ice Puzzle Cave",
@@ -77,8 +77,8 @@
     [
       {
         "ConnectedArea": "Lanayru Field",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash"
       },
       {
         "ConnectedArea": "Zoras Domain West Ledge",
@@ -95,13 +95,13 @@
     [
       {
         "ConnectedArea": "Lanayru Field",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash"
       },
       {
         "ConnectedArea": "Lake Hylia Bridge",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash"
       }
     ],
     "Checks":
@@ -276,8 +276,8 @@
       },
       {
         "ConnectedArea": "Faron Field Behind Boulder",
-        "Requirements": "canGetHotSpringWater",
-        "GlitchedRequirements": "canGetHotSpringWater"
+        "Requirements": "CanGetHotSpringWater",
+        "GlitchedRequirements": "CanGetHotSpringWater"
       },
       {
         "ConnectedArea": "Lake Hylia",
@@ -310,8 +310,8 @@
     [
       {
         "ConnectedArea": "Outside Castle Town South",
-        "Requirements": "canGetHotSpringWater and Room.Outside_Castle_Town_South",
-        "GlitchedRequirements": "canGetHotSpringWater and Room.Outside_Castle_Town_South"
+        "Requirements": "CanGetHotSpringWater and Room.Outside_Castle_Town_South",
+        "GlitchedRequirements": "CanGetHotSpringWater and Room.Outside_Castle_Town_South"
       }
     ],
     "Checks": [""],
@@ -339,13 +339,13 @@
     [
       {
         "ConnectedArea": "Lake Hylia Bridge Grotto Ledge",
-        "Requirements": "canLaunchBombs and (Progressive_Clawshot, 1)",
-        "GlitchedRequirements": "canLaunchBombs and (Progressive_Clawshot, 1)"
+        "Requirements": "CanLaunchBombs and (Progressive_Clawshot, 1)",
+        "GlitchedRequirements": "CanLaunchBombs and (Progressive_Clawshot, 1)"
       },
       {
         "ConnectedArea": "Hyrule Field Near Spinner Rails",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash or CanDoMapGlitch"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash or CanDoMapGlitch"
       },
       {
         "ConnectedArea": "Outside Castle Town West",

--- a/Generator/World/Rooms/Overworld/Lanayru Province/Lake Hylia.jsonc
+++ b/Generator/World/Rooms/Overworld/Lanayru Province/Lake Hylia.jsonc
@@ -5,8 +5,8 @@
     [
       {
         "ConnectedArea": "Lake Hylia Cave Entrance",
-        "Requirements": "canSmash and CanWarpMeteor",
-        "GlitchedRequirements": "canSmash and CanWarpMeteor"
+        "Requirements": "CanSmash and CanWarpMeteor",
+        "GlitchedRequirements": "CanSmash and CanWarpMeteor"
       },
       {
         "ConnectedArea": "Lake Hylia Lakebed Temple Entrance",
@@ -75,7 +75,7 @@
         "ConnectedArea": "Lake Hylia Shell Blade Grotto",
         "Requirements": "Shadow_Crystal and CanCompleteLanayruTwilight",
         "GlitchedRequirements": "Shadow_Crystal and CanCompleteLanayruTwilight"
-      },
+      }
     ],
     "Checks":[
       "Outside Lanayru Spring Left Statue Chest",
@@ -96,8 +96,8 @@
     [
       {
         "ConnectedArea": "Lake Hylia",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash"
       },
       {
         "ConnectedArea": "Lake Hylia Long Cave",

--- a/Generator/World/Rooms/Overworld/Lanayru Province/Zoras Domain.jsonc
+++ b/Generator/World/Rooms/Overworld/Lanayru Province/Zoras Domain.jsonc
@@ -95,8 +95,8 @@
     [
       {
         "ConnectedArea": "Zoras Domain West Ledge",
-        "Requirements": "(Progressive_Clawshot, 1) or Shadow_Crystal or canSmash",
-        "GlitchedRequirements": "(Progressive_Clawshot, 1) or Shadow_Crystal or canSmash"
+        "Requirements": "(Progressive_Clawshot, 1) or Shadow_Crystal or CanSmash",
+        "GlitchedRequirements": "(Progressive_Clawshot, 1) or Shadow_Crystal or CanSmash"
       },
       {
         "ConnectedArea": "Upper Zoras River",
@@ -153,8 +153,8 @@
       },
       {
         "ConnectedArea": "Zoras Domain Top of Waterfall",
-        "Requirements": "canSmash",
-        "GlitchedRequirements": "canSmash"
+        "Requirements": "CanSmash",
+        "GlitchedRequirements": "CanSmash"
       },
       {
         "ConnectedArea": "Lanayru Field Behind Boulder",

--- a/Generator/World/Rooms/Overworld/Ordona Province/Ordon.jsonc
+++ b/Generator/World/Rooms/Overworld/Ordona Province/Ordon.jsonc
@@ -290,7 +290,7 @@
       },
       {
         "ConnectedArea": "Ordon Bridge",
-        "Requirements": "(Room.Outside_Links_House and HasSword and Slingshot) or canCompletePrologue",
+        "Requirements": "(Room.Outside_Links_House and HasSword and Slingshot) or CanCompletePrologue",
         // Gate clip
         "GlitchedRequirements": "true"
       }
@@ -307,8 +307,8 @@
     [
       {
         "ConnectedArea": "Ordon Spring",
-        "Requirements": "(Room.Outside_Links_House and HasSword and Slingshot) or canCompletePrologue",
-        "GlitchedRequirements": "(Room.Outside_Links_House and HasSword and Slingshot) or canCompletePrologue"
+        "Requirements": "(Room.Outside_Links_House and HasSword and Slingshot) or CanCompletePrologue",
+        "GlitchedRequirements": "(Room.Outside_Links_House and HasSword and Slingshot) or CanCompletePrologue"
       },
       {
         "ConnectedArea": "South Faron Woods",

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -199,7 +199,7 @@
             <fieldset id="worldOptionsFieldset">
               <legend>World</legend>
               <div
-                data-tooltip-text="If checked, when starting a new save file, instead of starting in Ordon, the starting spawn point will be randomized.&#0010;&#0010;Note: Enabling this setting also forces the Prologue to be skipped.&#0010;"
+                data-tooltip-text="If checked, when starting a new save file, instead of starting in Ordon, the starting spawn point will be randomized.&#0010;"
               >
                 <input
                   type="checkbox"
@@ -216,7 +216,7 @@
                 <select
                   name="Shuffle Dungeon Entrances Fieldset"
                   id="dungeonERFieldset"
-                  data-tooltip-text="Adds dungeon entrances to the entrance pool.&#0010;&#0010;'Off': Dungeon entrances are vanilla.&#0010;&#0010;'Dungeons': The 8 main dungeons' entrances are shuffled.&#0010;&#0010;'Dungeons & Hyrule': All dungeons and Hyrule Castle will have their entrances shuffled.&#0010;&#0010;Note: Shuffling dungeon entrances forces MDH to be skipped.&#0010;"
+                  data-tooltip-text="Adds dungeon entrances to the entrance pool.&#0010;&#0010;'Off': Dungeon entrances are vanilla.&#0010;&#0010;'Dungeons': The 8 main dungeons' entrances are shuffled.&#0010;&#0010;'Dungeons & Hyrule': All dungeons and Hyrule Castle will have their entrances shuffled.&#0010;"
                 >
                   <option value="0">Off</option>
                   <option value="1">Dungeons</option>
@@ -236,7 +236,7 @@
                 </select>
               </div>
               <div
-                data-tooltip-text="If checked, entrances that seemingly go to the same place are randomized.&#0010;&#0010;Example: SPR Left Door and Right Doors could potentially lead to different places.&#0010;&#0010;Note: This option is only available if you have dungeon entrances randomized.&#0010;"
+                data-tooltip-text="If checked, entrances that seemingly go to the same place are randomized.&#0010;&#0010;Example: SPR Left Door and Right Doors could potentially lead to different places.&#0010;&#0010;Note: This option is only available if you have entrances randomized.&#0010;"
               >
                 <input
                   type="checkbox"
@@ -249,7 +249,7 @@
                 ><br />
               </div>
               <div
-                data-tooltip-text="If checked, entrances are de-coupled, meaning that going back the way you came could lead you to somewhere else.&#0010;&#0010;Example: If you enter FT from North Faron and then leave the dungeon the way you entered, you could end up in Lake Hylia.&#0010;&#0010;Note: This option is only available if you have dungeon entrances randomized.&#0010;"
+                data-tooltip-text="If checked, entrances are de-coupled, meaning that going back the way you came could lead you to somewhere else.&#0010;&#0010;Example: If you enter FT from North Faron and then leave the dungeon the way you entered, you could end up in Lake Hylia.&#0010;&#0010;Note: This option is only available if you have entrances randomized.&#0010;"
               >
                 <input
                   type="checkbox"

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -199,7 +199,7 @@
             <fieldset id="worldOptionsFieldset">
               <legend>World</legend>
               <div
-                data-tooltip-text="If checked, when starting a new save file, instead of starting in Ordon, the starting spawn point will be randomized.&#0010;"
+                data-tooltip-text="If checked, when starting a new save file, instead of starting in Ordon, the starting spawn point will be randomized.&#0010;&#0010;Note: Enabling this setting also forces the Prologue to be skipped.&#0010;"
               >
                 <input
                   type="checkbox"
@@ -216,7 +216,7 @@
                 <select
                   name="Shuffle Dungeon Entrances Fieldset"
                   id="dungeonERFieldset"
-                  data-tooltip-text="Adds dungeon entrances to the entrance pool.&#0010;&#0010;'Off': Dungeon entrances are vanilla.&#0010;&#0010;'Dungeons': The 8 main dungeons' entrances are shuffled.&#0010;&#0010;'Dungeons & Hyrule': All dungeons and Hyrule Castle will have their entrances shuffled.&#0010;"
+                  data-tooltip-text="Adds dungeon entrances to the entrance pool.&#0010;&#0010;'Off': Dungeon entrances are vanilla.&#0010;&#0010;'Dungeons': The 8 main dungeons' entrances are shuffled.&#0010;&#0010;'Dungeons & Hyrule': All dungeons and Hyrule Castle will have their entrances shuffled.&#0010;&#0010;Note: Shuffling dungeon entrances forces MDH to be skipped.&#0010;"
                 >
                   <option value="0">Off</option>
                   <option value="1">Dungeons</option>
@@ -236,7 +236,7 @@
                 </select>
               </div>
               <div
-                data-tooltip-text="If checked, entrances that seemingly go to the same place are randomized.&#0010;&#0010;Example: SPR Left Door and Right Doors could potentially lead to different places.&#0010;&#0010;Note: This option is only available if you have entrances randomized.&#0010;"
+                data-tooltip-text="If checked, entrances that seemingly go to the same place are randomized.&#0010;&#0010;Example: SPR Left Door and Right Doors could potentially lead to different places.&#0010;&#0010;Note: This option is only available if you have dungeon entrances randomized.&#0010;"
               >
                 <input
                   type="checkbox"
@@ -249,7 +249,7 @@
                 ><br />
               </div>
               <div
-                data-tooltip-text="If checked, entrances are de-coupled, meaning that going back the way you came could lead you to somewhere else.&#0010;&#0010;Example: If you enter FT from North Faron and then leave the dungeon the way you entered, you could end up in Lake Hylia.&#0010;&#0010;Note: This option is only available if you have entrances randomized.&#0010;"
+                data-tooltip-text="If checked, entrances are de-coupled, meaning that going back the way you came could lead you to somewhere else.&#0010;&#0010;Example: If you enter FT from North Faron and then leave the dungeon the way you entered, you could end up in Lake Hylia.&#0010;&#0010;Note: This option is only available if you have dungeon entrances randomized.&#0010;"
               >
                 <input
                   type="checkbox"


### PR DESCRIPTION
Aims to correct any `canSmash` like function names to follow the naming convention `CanSmash`; same goes for `hasBombs` like names.

I have scanned other files, and did not find any calls to the functions I corrected.

I will warn that I cannot currently test my changes, so there might be an issue somewhere.

Furthermore, I tried to prevent changing comments and did a couple passes to check that I had not, If any comments have wonky caps, apologies.