### PR TITLE
Update Snowpeak Ruins Lobby Chandelier Chest.jsonc

### DIFF
--- a/Generator/World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Lobby Chandelier Chest.jsonc
+++ b/Generator/World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Lobby Chandelier Chest.jsonc
@@ -1,5 +1,5 @@
 {
-    "requirements": "(((Snowpeak_Ruins_Small_Key, 3) and Snowpeak_Ruins_Ordon_Goat_Cheese)) and Ball_and_Chain",
+    "requirements": "(((Snowpeak_Ruins_Small_Key, 3) and Snowpeak_Ruins_Ordon_Goat_Cheese)) and Ball_and_Chain and Shadow_Crystal",
     "glitchedRequirements": "((((Snowpeak_Ruins_Small_Key, 3) and Snowpeak_Ruins_Ordon_Goat_Cheese)) and Ball_and_Chain) or (Shadow_Crystal and CanDoLJA)",
     "checkCategory": ["Chest", "Dungeon", "Snowpeak Ruins"],
     "itemId": "Piece_of_Heart"


### PR DESCRIPTION
Added Shadow Crystal as a requirement for the poe below. Doing it without Crystal is doable, but way more annoying and very tedious, if you don't have a Clawshot.

This can probably be added as a trick later, but for now, I feel like expecting somebody to do that without Crystal is... a bit too much.