### PR TITLE
Fix incorrect logic for the Fishing Hole PoH

### DIFF
--- a/Generator/World/Checks/Overworld/Lanayru Province/Fishing Hole Heart Piece.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Fishing Hole Heart Piece.jsonc
@@ -1,6 +1,6 @@
 {
-    "requirements": "Room.Fishing_Hole_House or (Progressive_Clawshot, 1)",
-    "glitchedRequirements": "Room.Fishing_Hole_House or (Progressive_Clawshot, 1)",
+    "requirements": "true",
+    "glitchedRequirements": "true",
     "checkCategory": ["Overworld", "Fishing Hole"],
     "itemId": "Piece_of_Heart"
 }

--- a/Generator/World/Rooms/Overworld/Lanayru Province/Zoras Domain.jsonc
+++ b/Generator/World/Rooms/Overworld/Lanayru Province/Zoras Domain.jsonc
@@ -67,11 +67,15 @@
         "ConnectedArea": "Fishing Hole House",
         "Requirements": "true",
         "GlitchedRequirements": "true"
+      },
+      {
+        "ConnectedArea": "Fishing Hole Piece of Heart",
+        "Requirements": "(Progressive_Clawshot, 1)",
+        "GlitchedRequirements": "(Progressive_Clawshot, 1)"
       }
     ],
     "Checks":
     [
-        "Fishing Hole Heart Piece",
         "Fishing Hole Bottle"
     ],
     "Region": "Zoras Domain"
@@ -84,9 +88,23 @@
         "ConnectedArea": "Fishing Hole",
         "Requirements": "true",
         "GlitchedRequirements": "true"
+      },
+      {
+        "ConnectedArea": "Fishing Hole Piece of Heart",
+        "Requirements": "true",
+        "GlitchedRequirements": "true"
       }
     ],
     "Checks": [""],
+    "Region": "Zoras Domain"
+  },
+  {
+    "RoomName": "Fishing Hole Piece of Heart",
+    "Exits": [],
+    "Checks":
+    [
+        "Fishing Hole Heart Piece"
+    ],
     "Region": "Zoras Domain"
   },
   {


### PR DESCRIPTION
Since the PoH can be collected in two different rooms, the current logic requires access to the fishing hole, even if you found the fishing hole house and can get it from there without the need to actually visit the fishing hole itself. To fix this, this PR creates a fake room "Fishing Hole Piece of Heart", which is accessible from both fishing hole and fishing hole house, and the PoH can be collected from there. I got inspired by OoT Rando, because they did the same with the cow in Impas house and the checks you can choose to skip and start with their respective items instead.