### PR TITLE
Fix dungeons could be erroneously considered required

### DIFF
--- a/Generator/Randomizer.cs
+++ b/Generator/Randomizer.cs
@@ -1587,12 +1587,11 @@ namespace TPRandomizer
             // Example, if 2 Fused Shadows are required to complete the seed and the is one in Forest, one in Mines, and one in City, we want all 3 dungeons to be listed as required because they do contain an item required to complete the seed.
             for (int i = 0; i < listOfRequiredDungeons.GetLength(0); i++)
             {
-                requiredDungeons reqDungeon = listOfRequiredDungeons[i];
                 // We can skip checking to mark a dungeon as required when it is
                 // already marked as required.
-                if (!reqDungeon.isRequired)
+                if (!listOfRequiredDungeons[i].isRequired)
                 {
-                    foreach (string dungeonCheck in reqDungeon.requirementChecks)
+                    foreach (string dungeonCheck in listOfRequiredDungeons[i].requirementChecks)
                     {
                         Check check = Randomizer.Checks.CheckDict[dungeonCheck];
                         // Note: we must confirm the itemWasPlaced so we don't
@@ -1601,7 +1600,7 @@ namespace TPRandomizer
                         // assigned an item.
                         if (check.itemWasPlaced && requiredItems.Contains(check.itemId))
                         {
-                            reqDungeon.isRequired = true;
+                            listOfRequiredDungeons[i].isRequired = true;
                             break;
                         }
                     }

--- a/Generator/Randomizer.cs
+++ b/Generator/Randomizer.cs
@@ -1542,7 +1542,6 @@ namespace TPRandomizer
             Console.WriteLine("Checking Required Dungeons!");
             // Now loop through all dungeons and validate the necessity of every check related to the dungeon.
 
-
             Dictionary<string, Item> checkData = new();
             List<Item> requiredItems = new();
             for (int i = 0; i < listOfRequiredDungeons.GetLength(0); i++)


### PR DESCRIPTION
- Fixed scenario where a dungeon reward check which did not yet have its item placed (so it had its vanilla reward; ex: LBT with a Fused Shadow) was still being marked as required when Fused Shadows were required. This could lead to marking a 4th dungeon as required even when there were only 3 dungeons which ended up with Fused Shadows.
- Skipped unnecessary checking of if a playthrough was beatable when adjusting the contents of checks which had not yet had an item placed. This reduced the execution time of this section of the code from approximately ~700ms to  ~105ms (at least when debugging in VSCode).