### PR TITLE
Add GM shortcut setting (magnets start activated)

### DIFF
--- a/Generator/Assets/Flags.cs
+++ b/Generator/Assets/Flags.cs
@@ -402,6 +402,35 @@ namespace TPRandomizer.Assets
             { 0x15, 0xBF }, // statue placed in slot in room 1
         };
 
+        public static readonly byte[,] GmShortcutFlags = new byte[,]
+        {
+            { 0x11, 0xBB }, // activated magnet from water before first elder
+            { 0x11, 0x8F }, // activated ceiling maze magnet after first elder
+            { 0x11, 0x5B }, // activated main magnet room 1st magnet
+            { 0x11, 0x4A }, // watched main magnet room 1st magnet cs
+            { 0x11, 0x61 }, // activated main magnet room 2nd magnet
+            { 0x11, 0x44 }, // watched main magnet room 2nd magnet cs
+            { 0x11, 0x9E }, // crystal switch room 1st Iron Boots switch pressed
+            { 0x11, 0x83 }, // crystal switch room 1st Iron Boots switch cs shown
+            { 0x11, 0x82 }, // crystal switch room 1st magnet active
+            { 0x11, 0x9F }, // crystal switch room 2nd Iron Boots switch pressed
+            { 0x11, 0x85 }, // crystal switch room 2nd Iron Boots switch cs shown
+            { 0x11, 0x86 }, // crystal switch room 2nd magnet active
+            { 0x11, 0x54 }, // activated outside room magnet
+            { 0x11, 0x68 }, // watched outside room magnet cs
+            { 0x11, 0x8d }, // activated east wing dodongo room magnet
+            // Note: the final magnet is not activated because there is a
+            // softlock when you exit the main magnet room through the top door
+            // as wolf while the gate beyond the door in the Dodongo room is not
+            // open. Alternatively if we do open this gate, it leads to much
+            // more complicated logic and some jank where you can walk through
+            // Dangoro while he sits there (and the gate covering the door
+            // animation is also a bit jank). Also you can die during the
+            // Dangoro fight to appear on the north side of his arena. There are
+            // too many nuances for it to be reasonable for glitchless logic,
+            // and also every small key door would require 3 keys.
+        };
+
         public static readonly byte[,] HcShortcutFlags = new byte[,]
         {
             { 0x18, 0x6F }, // watched double Dinalfos cs 1
@@ -537,6 +566,7 @@ namespace TPRandomizer.Assets
                 { 28, DungeonERRegionFlags },
                 { 29, HCBKRegionFlags },
                 { 30, bridgeDonationRegionFlags },
+                { 31, GmShortcutFlags },
             };
 
         /// <summary>
@@ -791,6 +821,7 @@ namespace TPRandomizer.Assets
             /* 28 */RandomizerSettings.shuffleDungeonEntrances != DungeonER.Off,
             /* 29 */RandomizerSettings.castleBKRequirements == CastleBKRequirements.None,
             /* 30 */RandomizerSettings.skipBridgeDonation,
+            /* 31 */RandomizerSettings.gmShortcut,
         };
     }
 }

--- a/Generator/Logic/SeedGenResults.cs
+++ b/Generator/Logic/SeedGenResults.cs
@@ -708,6 +708,7 @@ namespace TPRandomizer
             result.Add("hintDistribution", sSettings.hintDistribution.ToString());
             result.Add("randomizeStartingPoint", sSettings.randomizeStartingPoint);
             result.Add("shuffleHiddenRupees", sSettings.shuffleHiddenRupees);
+            result.Add("gmShortcut", sSettings.gmShortcut);
             result.Add("hcShortcut", sSettings.hcShortcut);
             result.Add("iliaQuest", sSettings.iliaQuest.ToString());
             result.Add("mirrorChamberEntrance", sSettings.mirrorChamberEntrance.ToString());

--- a/Generator/Logic/SharedSettings.cs
+++ b/Generator/Logic/SharedSettings.cs
@@ -59,6 +59,7 @@ namespace TPRandomizer
         public bool increaseSpinnerSpeed { get; set; }
         public bool openDot { get; set; }
         public bool noSmallKeysOnBosses { get; set; }
+        public bool gmShortcut { get; set; }
         public bool hcShortcut { get; set; }
         public StartingToD startingToD { get; set; }
         public HintDistribution hintDistribution { get; set; }
@@ -132,6 +133,7 @@ namespace TPRandomizer
             hintDistribution = (HintDistribution)processor.NextInt(5);
             randomizeStartingPoint = processor.NextBool();
             shuffleHiddenRupees = processor.NextBool();
+            gmShortcut = processor.NextBool();
             hcShortcut = processor.NextBool();
             iliaQuest = (IliaQuest)processor.NextInt(3);
             mirrorChamberEntrance = (MirrorChamberEntrance)processor.NextInt(2);

--- a/Generator/World/Rooms/Dungeons/Goron Mines.jsonc
+++ b/Generator/World/Rooms/Dungeons/Goron Mines.jsonc
@@ -91,13 +91,16 @@
             },
             {
                 "ConnectedArea": "Goron Mines Lower West Wing",
-                "Requirements": "(Goron_Mines_Small_Key, 1)",
-                "GlitchedRequirements": "(Goron_Mines_Small_Key, 1)"
+                "Requirements": "(Goron_Mines_Small_Key, 1) or ((Setting.gmShortcut equals True) and Iron_Boots)",
+                "GlitchedRequirements": "(Goron_Mines_Small_Key, 1) or ((Setting.gmShortcut equals True) and Iron_Boots)"
             },
+            // Note the difference in the parentheses between this and the
+            // previous exit. The previous exit only requires IB when using the
+            // shortcut magnet, but the below exit always required IB.
             {
                 "ConnectedArea": "Goron Mines Crystal Switch Room",
-                "Requirements": "(Goron_Mines_Small_Key, 1) and Iron_Boots",
-                "GlitchedRequirements": "(Goron_Mines_Small_Key, 1) and Iron_Boots"
+                "Requirements": "((Goron_Mines_Small_Key, 1) or (Setting.gmShortcut equals True)) and Iron_Boots",
+                "GlitchedRequirements": "((Goron_Mines_Small_Key, 1) or (Setting.gmShortcut equals True)) and Iron_Boots"
             }
         ],
         "Checks": 

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -717,6 +717,20 @@
               </div>
               <div
                 style="width: 90%"
+                data-tooltip-text="If enabled, all magnets within Goron Mines except the final one will automatically be activated. The final magnet remains deactivated to avoid a softlock."
+              >
+                <input
+                  type="checkbox"
+                  id="gmShortcutCheckbox"
+                  name="Active Goron Mines Magnets"
+                  value=""
+                />
+                <label for="gmShortcutCheckbox"
+                  >Active Goron Mines Magnets</label
+                ><br />
+              </div>
+              <div
+                style="width: 90%"
                 data-tooltip-text="If enabled, the shortcut chandelier in the Hyrule Castle main hall will be lowered, and the double Dinalfos room will be cleared.&#0010;&#0010;This allows for you to continue from the main hall to the southern balcony more quickly and with fewer item requirements (ex: no Gale Boomerang)."
               >
                 <input

--- a/packages/client/js/shared.js
+++ b/packages/client/js/shared.js
@@ -443,6 +443,7 @@
       { id: 'hintDistributionFieldset', bitLength: 5 },
       { id: 'randomizeStartingPointCheckbox' },
       { id: 'hiddenRupeeCheckbox' },
+      { id: 'gmShortcutCheckbox' },
       { id: 'hcShortcutCheckbox' },
       { id: 'iliaQuestFieldset', bitLength: 3 },
       { id: 'mirrorChamberFieldset', bitLength: 2 },
@@ -853,12 +854,9 @@
         large: 3,
       };
       const walletSizeValue = processor.nextBoolean();
-      if (walletSizeValue)
-      {
+      if (walletSizeValue) {
         res.walletSize = walletSize.large;
-      }
-      else
-      {
+      } else {
         res.walletSize = walletSize.vanilla;
       }
     }
@@ -954,6 +952,7 @@
     if (version >= 6) {
       processBasic({ id: 'randomizeStartingPoint' });
       processBasic({ id: 'hiddenRupees' });
+      processBasic({ id: 'gmShortcut' });
       processBasic({ id: 'hcShortcut' });
       processBasic({ id: 'iliaQuest', bitLength: 3 });
       processBasic({ id: 'mirrorChamber', bitLength: 2 });
@@ -970,6 +969,7 @@
     } else {
       res.randomizeStartingPoint = false; // Vanilla
       res.hiddenRupees = false; // Vanilla
+      res.gmShortcut = false;
       res.hcShortcut = false;
       res.iliaQuest = 0; // Vanilla
       res.mirrorChamber = 0; // Vanilla
@@ -977,28 +977,23 @@
       res.unpairEntrances = false; // Vanilla
       res.decoupleEntrances = false; // Vanilla
       res.freestandingRupees = false; // Vanilla
-      switch(res.castleRequirements)
-      {
-        case 1:
-          {
-            res.castleRequirementCount = 3;
-            break;
-          }
-        case 2:
-            {
-              res.castleRequirementCount = 4;
-              break;
-            }
-        case 3:
-          {
-            res.castleRequirementCount = 8;
-            break;
-          }
-        default:
-          {
-            res.castleRequirementCount = 1;
-            break;
-          }
+      switch (res.castleRequirements) {
+        case 1: {
+          res.castleRequirementCount = 3;
+          break;
+        }
+        case 2: {
+          res.castleRequirementCount = 4;
+          break;
+        }
+        case 3: {
+          res.castleRequirementCount = 8;
+          break;
+        }
+        default: {
+          res.castleRequirementCount = 1;
+          break;
+        }
       }
       res.castleBKRequirements = 0;
       res.castleBKRequirementCount = 1;

--- a/packages/client/script.js
+++ b/packages/client/script.js
@@ -606,6 +606,9 @@ document
   .getElementById('hiddenRupeeCheckbox')
   .addEventListener('click', setSettingsString);
 document
+  .getElementById('gmShortcutCheckbox')
+  .addEventListener('click', setSettingsString);
+document
   .getElementById('hcShortcutCheckbox')
   .addEventListener('click', setSettingsString);
 document.getElementById('itemScarcityFieldset').onchange = setSettingsString;
@@ -2337,6 +2340,7 @@ function populateSSettings(s) {
     s.randomizeStartingPoint
   );
   $('#hiddenRupeeCheckbox').prop('checked', s.hiddenRupees);
+  $('#gmShortcutCheckbox').prop('checked', s.gmShortcut);
   $('#hcShortcutCheckbox').prop('checked', s.hcShortcut);
   $('#iliaQuestFieldset').val(s.iliaQuest);
   $('#mirrorChamberFieldset').val(s.mirrorChamber);


### PR DESCRIPTION
- Add checkbox to start with all GM magnets already activated except the final one. The main important one is the shortcut in the main magnet room, but having the others already on is convenient as well.
- Regarding why the final magnet is not enabled: there is a softlock if you exit through the door at the top of the room into the Dodongo room as wolf while the gate beyond the door is still closed. However if we were to open this gate then logic would be a lot more involved and there is some unavoidable jank with the Dangoro room. Also every small key door could be your 3rd one, so they would all require 3 small keys.