### PR TITLE
Fix intermittent issues (oil refill and dungeon check calc issues)

### DIFF
--- a/Generator/Assets/Checks.cs
+++ b/Generator/Assets/Checks.cs
@@ -97,7 +97,6 @@ namespace TPRandomizer
         public static List<string> minesRequirementChecks =
             new()
             {
-                "Death Mountain Trail Poe",
                 "Goron Mines After Crystal Switch Room Magnet Wall Chest",
                 "Goron Mines Beamos Room Chest",
                 "Goron Mines Chest Before Dangoro",
@@ -284,7 +283,12 @@ namespace TPRandomizer
             };
 
         public static List<string> postFyrusChecks =
-            new() { "Kakariko Village Malo Mart Hawkeye", "Talo Sharpshooting", };
+            new()
+            {
+                "Kakariko Village Malo Mart Hawkeye",
+                "Talo Sharpshooting",
+                "Death Mountain Trail Poe",
+            };
 
         public static List<string> postBlizettaChecks = new() { "Snowboard Racing Prize", };
 

--- a/Generator/Hints/HintCreator/BarrenHintCreator.cs
+++ b/Generator/Hints/HintCreator/BarrenHintCreator.cs
@@ -2,6 +2,7 @@ namespace TPRandomizer.Hints.HintCreator
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Newtonsoft.Json.Linq;
     using TPRandomizer.Hints;
     using TPRandomizer.Hints.Settings;
@@ -39,6 +40,32 @@ namespace TPRandomizer.Hints.HintCreator
                 { Zone.Temple_of_Time, CheckFunctions.totRequirementChecks },
                 { Zone.City_in_the_Sky, CheckFunctions.cityRequirementChecks },
                 { Zone.Palace_of_Twilight, CheckFunctions.palaceRequirementChecks },
+            };
+
+        private static readonly Dictionary<Zone, string> dungeonZoneToRegionName =
+            new()
+            {
+                { Zone.Forest_Temple, "Forest Temple" },
+                { Zone.Goron_Mines, "Goron Mines" },
+                { Zone.Lakebed_Temple, "Lakebed Temple" },
+                { Zone.Arbiters_Grounds, "Arbiters Grounds" },
+                { Zone.Snowpeak_Ruins, "Snowpeak Ruins" },
+                { Zone.Temple_of_Time, "Temple of Time" },
+                { Zone.City_in_the_Sky, "City in The Sky" },
+                { Zone.Palace_of_Twilight, "Palace of Twilight" },
+            };
+
+        private static readonly List<string> bossRooms =
+            new()
+            {
+                "Forest Temple Boss Room",
+                "Goron Mines Boss Room",
+                "Lakebed Temple Boss Room",
+                "Arbiters Grounds Boss Room",
+                "Snowpeak Ruins Boss Room",
+                "Temple of Time Boss Room",
+                "City in The Sky Boss Room",
+                "Palace of Twilight Boss Room",
             };
 
         private static readonly HashSet<AreaId.AreaType> validAreaTypes =
@@ -274,13 +301,51 @@ namespace TPRandomizer.Hints.HintCreator
             if (areaId.type == AreaId.AreaType.Zone)
             {
                 Zone zone = ZoneUtils.StringToId(areaId.stringId);
-                if (dungeonZoneToReqChecks.TryGetValue(zone, out List<string> checksList))
+                if (dungeonZoneToReqChecks.TryGetValue(zone, out List<string> baseDungeonChecks))
                 {
-                    return new(checksList);
+                    List<string> bossAndPostDungeonChecks = ResolveBossAndPostDungeonChecks(zone);
+
+                    return new(baseDungeonChecks.Concat(bossAndPostDungeonChecks));
                 }
             }
 
             return areaId.ResolveToChecks();
+        }
+
+        private List<string> ResolveBossAndPostDungeonChecks(Zone zone)
+        {
+            if (!dungeonZoneToRegionName.TryGetValue(zone, out string dungeonRegionName))
+                throw new Exception($"Failed to find dungeonRegionName for Zone '{zone}'.");
+
+            // Given a dungeon, we need to scan through the boss rooms until we
+            // find the one that is hooked up to the end of the dungeon.
+            foreach (string bossRoom in bossRooms)
+            {
+                Room bRoom = Randomizer.Rooms.RoomDict[bossRoom];
+                if (bRoom.Region == dungeonRegionName)
+                {
+                    // Add bossRoom checks to result as well as any post-dungeon
+                    // checks based on the boss (ex: post-Fyrus checks block
+                    // barren for FT if Fyrus is randomized to be the boss at
+                    // the end of FT).
+                    List<string> result = new(bRoom.Checks);
+                    switch (bossRoom)
+                    {
+                        case "Goron Mines Boss Room":
+                            result.AddRange(CheckFunctions.postFyrusChecks);
+                            break;
+                        case "Snowpeak Ruins Boss Room":
+                            result.AddRange(CheckFunctions.postBlizettaChecks);
+                            break;
+                        case "Temple of Time Boss Room":
+                            result.AddRange(CheckFunctions.postArmogohmaChecks);
+                            break;
+                    }
+                    return result;
+                }
+            }
+
+            throw new Exception($"Failed to find bossRoom for Zone '${zone}'.");
         }
 
         private HashSet<AreaId> GetBaseAreaIds(HintGenData genData, HintSettings hintSettings)

--- a/Generator/Logic/LogicFunctions.cs
+++ b/Generator/Logic/LogicFunctions.cs
@@ -32,55 +32,24 @@ namespace TPRandomizer
         }
 
         /// <summary>
-        /// A tempoarary function for CanUse and for HasDefeatedBoss.
-        /// </summary>
-        private static bool HasItem(Item item)
-        {
-            return Randomizer.Items.heldItems.Contains(item);
-        }
-
-        /// <summary>
         /// summary text.
         /// </summary>
         public static bool CanUse(Item item)
         {
-            if (HasItem(item) && CanReplenishItem(item))
-            {
-                return true;
-            }
-            return false;
+            return Randomizer.Items.heldItems.Contains(item) && CanReplenishItem(item);
         }
 
         public static bool CanReplenishItem(Item item)
         {
-            bool replenish = false;
             switch (item)
             {
                 case Item.Lantern:
-                {
-                    if (CanRefillOil())
-                    {
-                        replenish = true;
-                    }
-                    break;
-                }
-
+                    return CanRefillOil();
                 case Item.Progressive_Bow:
-                {
-                    if (CanGetArrows())
-                    {
-                        replenish = true;
-                    }
-                    break;
-                }
-
+                    return CanGetArrows();
                 default:
-                {
-                    replenish = true;
-                    break;
-                }
+                    return true;
             }
-            return replenish;
         }
 
         /// <summary>
@@ -1460,6 +1429,11 @@ namespace TPRandomizer
             return CanUse(Item.Lantern) || HasBombs() || CanUse(Item.Ball_and_Chain);
         }
 
+        public static bool CanDestroyWebsWithoutLantern()
+        {
+            return HasBombs() || CanUse(Item.Ball_and_Chain);
+        }
+
         /// <summary>
         /// summary text.
         /// </summary>
@@ -1705,6 +1679,12 @@ namespace TPRandomizer
 
         public static bool CanRefillOil()
         {
+            // Note: it is critical that this function does not rely on you
+            // having access to a functioning lantern. The question is "can you
+            // refill your oil if you ran out" which means you do not have
+            // access to the lantern here. To avoid a stack overflow from a
+            // circular dependency (and because it just makes sense), we check
+            // if you can destroy webs without the lantern in this function.
             return (
                 Randomizer.Rooms.RoomDict["North Faron Woods"].ReachedByPlaythrough
                 || Randomizer.Rooms.RoomDict["South Faron Woods"].ReachedByPlaythrough
@@ -1734,7 +1714,7 @@ namespace TPRandomizer
                 )
                 || (
                     Randomizer.Rooms.RoomDict["Eldin Lantern Cave"].ReachedByPlaythrough
-                    && CanBurnWebs()
+                    && CanDestroyWebsWithoutLantern()
                     && CanDefeatChu()
                 )
             );
@@ -1923,7 +1903,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanCompleteForestTemple()
         {
-            return HasItem(Item.Diababa_Defeated);
+            return CanUse(Item.Diababa_Defeated);
         }
 
         /// <summary>
@@ -1931,7 +1911,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanCompleteGoronMines()
         {
-            return HasItem(Item.Fyrus_Defeated);
+            return CanUse(Item.Fyrus_Defeated);
         }
 
         /// <summary>
@@ -1939,7 +1919,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanCompleteLakebedTemple()
         {
-            return HasItem(Item.Morpheel_Defeated);
+            return CanUse(Item.Morpheel_Defeated);
         }
 
         /// <summary>
@@ -1947,7 +1927,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanCompleteArbitersGrounds()
         {
-            return HasItem(Item.Stallord_Defeated);
+            return CanUse(Item.Stallord_Defeated);
         }
 
         /// <summary>
@@ -1955,7 +1935,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanCompleteSnowpeakRuins()
         {
-            return HasItem(Item.Blizzeta_Defeated);
+            return CanUse(Item.Blizzeta_Defeated);
         }
 
         /// <summary>
@@ -1963,7 +1943,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanCompleteTempleofTime()
         {
-            return HasItem(Item.Armogohma_Defeated);
+            return CanUse(Item.Armogohma_Defeated);
         }
 
         /// <summary>
@@ -1971,7 +1951,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanCompleteCityinTheSky()
         {
-            return HasItem(Item.Argorok_Defeated);
+            return CanUse(Item.Argorok_Defeated);
         }
 
         /// <summary>
@@ -1979,7 +1959,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanCompletePalaceofTwilight()
         {
-            return HasItem(Item.Zant_Defeated);
+            return CanUse(Item.Zant_Defeated);
         }
 
         /// <summary>

--- a/Generator/Logic/LogicFunctions.cs
+++ b/Generator/Logic/LogicFunctions.cs
@@ -1679,12 +1679,12 @@ namespace TPRandomizer
 
         public static bool CanRefillOil()
         {
-            // Note: it is critical that this function does not rely on you
-            // having access to a functioning lantern. The question is "can you
-            // refill your oil if you ran out" which means you do not have
-            // access to the lantern here. To avoid a stack overflow from a
-            // circular dependency (and because it just makes sense), we check
-            // if you can destroy webs without the lantern in this function.
+            // Note: we need to assume the worse-case scenario that the player
+            // has run out of oil when checking if they can refill the Lantern.
+            // This also prevents stack overflows where we check if they can
+            // refill oil in order to use Lantern in order to refill oil, etc.
+            // So for going through giant webs in order to find oil refills,
+            // using the Lantern is not valid.
             return (
                 Randomizer.Rooms.RoomDict["North Faron Woods"].ReachedByPlaythrough
                 || Randomizer.Rooms.RoomDict["South Faron Woods"].ReachedByPlaythrough

--- a/Generator/Randomizer.cs
+++ b/Generator/Randomizer.cs
@@ -1434,17 +1434,21 @@ namespace TPRandomizer
 
         private static void CheckUnrequiredDungeons(Room startingRoom)
         {
-            List<string>[] listOfAffectedChecks = new List<string>[]
-            {
-                CheckFunctions.palaceRequirementChecks,
-                CheckFunctions.cityRequirementChecks,
-                CheckFunctions.totRequirementChecks,
-                CheckFunctions.snowpeakRequirementChecks,
-                CheckFunctions.arbitersRequirementChecks,
-                CheckFunctions.lakebedRequirementChecks,
-                CheckFunctions.minesRequirementChecks,
-                CheckFunctions.forestRequirementChecks,
-            };
+            // Use shallow copies of the requirementChecks lists since we mutate
+            // them here and we may need to run this function multiple times.
+            // This change was to fix a bug.
+            List<List<string>> listOfAffectedChecks =
+                new()
+                {
+                    new(CheckFunctions.palaceRequirementChecks),
+                    new(CheckFunctions.cityRequirementChecks),
+                    new(CheckFunctions.totRequirementChecks),
+                    new(CheckFunctions.snowpeakRequirementChecks),
+                    new(CheckFunctions.arbitersRequirementChecks),
+                    new(CheckFunctions.lakebedRequirementChecks),
+                    new(CheckFunctions.minesRequirementChecks),
+                    new(CheckFunctions.forestRequirementChecks),
+                };
 
             // Create the dungeon entries
             requiredDungeons forestTemple = new("Forest Temple", false, null);
@@ -1504,19 +1508,19 @@ namespace TPRandomizer
                     if (bRoom.Region == DungeonNames[i])
                     {
                         listOfAffectedChecks[i].AddRange(bRoom.Checks);
-                        switch (DungeonNames[i])
+                        switch (bossRoom)
                         {
-                            case "Goron Mines":
+                            case "Goron Mines Boss Room":
                             {
                                 listOfAffectedChecks[i].AddRange(CheckFunctions.postFyrusChecks);
                                 break;
                             }
-                            case "Snowpeak Ruins":
+                            case "Snowpeak Ruins Boss Room":
                             {
                                 listOfAffectedChecks[i].AddRange(CheckFunctions.postBlizettaChecks);
                                 break;
                             }
-                            case "Temple of Time":
+                            case "Temple of Time Boss Room":
                             {
                                 listOfAffectedChecks[i].AddRange(
                                     CheckFunctions.postArmogohmaChecks


### PR DESCRIPTION
- Revert changes from earlier PR which did not fix the issue
- Simplify the code some
- Fix the issue by assuming you cannot use the lantern if you need to refill it.
- Fix issue which would cause generation failures related to mutating a list which should not have been mutated.
- Fix barren hint post-dungeon / boss check calculation. Should be prepped for randomized Boss rooms as well now.