### PR TITLE
Fix Magic Armor wallet logic bug for HD wallet size

### DIFF
--- a/Generator/Logic/LogicFunctions.cs
+++ b/Generator/Logic/LogicFunctions.cs
@@ -2215,18 +2215,12 @@ namespace TPRandomizer
         {
             switch (Randomizer.SSettings.walletSize)
             {
-                case WalletSize.Reduced:
-                {
-                    return GetItemCount(Item.Progressive_Wallet) >= 2;
-                }
-                case WalletSize.Vanilla:
-                {
-                    return CanUse(Item.Progressive_Wallet);
-                }
-                default:
-                {
+                case WalletSize.Large:
                     return true;
-                }
+                case WalletSize.Reduced:
+                    return GetItemCount(Item.Progressive_Wallet) >= 2;
+                default:
+                    return CanUse(Item.Progressive_Wallet);
             }
         }
 


### PR DESCRIPTION
- HD wallet size incorrectly thought you did not need a wallet upgrade to buy the Magic Armor check.