### PR TITLE
Fix edge case for when content size would be just over multiple of 0x2000

### DIFF
--- a/Generator/Assets/SeedData.cs
+++ b/Generator/Assets/SeedData.cs
@@ -2459,12 +2459,14 @@ namespace TPRandomizer.Assets
                     gciBytes[offset + 10] = (byte)((relOffset & 0xFF00) >> 8);
                     gciBytes[offset + 11] = (byte)(relOffset & 0xFF);
 
-                    // Calculate new size of gci
+                    // Calculate new size of gci.
+                    // First round content up to a block
                     int newSize = (int)(relOffset + SeedHeaderRaw.totalSize);
-                    while ((newSize - 0x40) % 0x2000 != 0)
+                    while (newSize % 0x2000 != 0)
                     {
                         newSize++;
                     }
+                    newSize += 0x40; // Then add room for the GCI header
 
                     while (gciBytes.Count < newSize)
                     {


### PR DESCRIPTION
- If the content size was something just over a multiple of a block, we would only add a few bytes which would not leave enough room for both the content and the header.
- For example, if the content was 0x1e008 bytes, then the size rounded up to 0x1e040. But this size would mean 0x1e000 content bytes + a header, and we need at least 0x1e008 bytes for the content. 