### PR TITLE
Hint adjustments: Snowpeak Dungeon ER stuff and Remove clawshot from ItemToItemPath

### DIFF
--- a/Generator/Hints/HintConstants.cs
+++ b/Generator/Hints/HintConstants.cs
@@ -191,11 +191,32 @@ namespace TPRandomizer.Hints
         private static readonly Func<HintGenData, Zone, bool> alwaysPassFn = (genData, zone) =>
             true;
         private static readonly Func<HintGenData, Zone, bool> snowpeakFn = (genData, zone) =>
-            !genData.sSettings.skipSnowpeakEntrance
-            && genData.sSettings.shufflePoes != PoeSettings.All
-            && genData.sSettings.shufflePoes != PoeSettings.Overworld
-            && genData.sSettings.barrenDungeons
-            && !HintUtils.DungeonIsRequired(ZoneUtils.IdToString(Zone.Snowpeak_Ruins));
+        {
+            if (
+                !genData.sSettings.skipSnowpeakEntrance
+                && genData.sSettings.shufflePoes != PoeSettings.All
+                && genData.sSettings.shufflePoes != PoeSettings.Overworld
+                && genData.sSettings.barrenDungeons
+                && !genData.sSettings.decoupleEntrances
+                && !genData.sSettings.unpairEntrances
+            )
+            {
+                if (
+                    !genData.dungeonEntrances.TryGetValue(
+                        Zone.Snowpeak_Ruins,
+                        out Zone beyondSprDoorsDungeon
+                    )
+                )
+                    throw new Exception(
+                        $"Failed to find dungeon behind SPR doors for Snowpeak BeyondThisPoint hint."
+                    );
+
+                // Dungeon behind the SPR doors must be an unrequiredBarren dungeon.
+                return !HintUtils.DungeonIsRequired(ZoneUtils.IdToString(beyondSprDoorsDungeon));
+            }
+            return false; // Don't create BeyondThisPoint hint
+        };
+
         private static readonly Func<HintGenData, Zone, bool> dungeonFn = (genData, zone) =>
             ZoneUtils.IsDungeonZone(zone)
             && (

--- a/Generator/Hints/HintCreator/ItemToItemPathHintCreator.cs
+++ b/Generator/Hints/HintCreator/ItemToItemPathHintCreator.cs
@@ -48,11 +48,12 @@ namespace TPRandomizer.Hints.HintCreator
                     Item.Iron_Boots,
                     Item.Progressive_Bow,
                     Item.Filled_Bomb_Bag,
-                    Item.Progressive_Clawshot,
                     Item.Aurus_Memo,
                     Item.Spinner,
                     Item.Ball_and_Chain,
                     Item.Progressive_Dominion_Rod,
+                    // Note: Clawshot leads to far too many checks to be
+                    // helpful, so removed from this base list.
                 };
 
             // Remove any baseSrcItems which have a check that is already

--- a/Generator/Hints/HintGenData.cs
+++ b/Generator/Hints/HintGenData.cs
@@ -29,6 +29,7 @@ namespace TPRandomizer.Hints
         public Dictionary<string, Item> tradeChainStartToReward = new();
         public Dictionary<Item, string> tradeItemToChainEndCheck = new();
         public Dictionary<AreaId, HashSet<Item>> areaIdToAllowBarrenItems { get; private set; }
+        public Dictionary<Zone, Zone> dungeonEntrances = new(); // Entering Key sends to Value
 
         public HintGenData(
             Random rnd,
@@ -44,6 +45,7 @@ namespace TPRandomizer.Hints
             hinted = new HintedThings3();
             vars = new HintVars();
 
+            dungeonEntrances = calcDungeonEntrances();
             areaIdToAllowBarrenItems = prepareAreaIdToAllowBarrenItems();
             itemToChecksList = calcItemToChecksList();
             prepareTradeItemData();
@@ -652,6 +654,111 @@ namespace TPRandomizer.Hints
             }
 
             return false;
+        }
+
+        private Dictionary<Zone, Zone> calcDungeonEntrances()
+        {
+            Dictionary<Zone, Zone> result = new();
+
+            List<(string, string, Zone)> exitToDungeonList =
+                new()
+                {
+                    ("North Faron Woods", "Forest Temple Entrance", Zone.Forest_Temple),
+                    (
+                        "Death Mountain Sumo Hall Goron Mines Tunnel",
+                        "Goron Mines Entrance",
+                        Zone.Goron_Mines
+                    ),
+                    (
+                        "Lake Hylia Lakebed Temple Entrance",
+                        "Lakebed Temple Entrance",
+                        Zone.Lakebed_Temple
+                    ),
+                    (
+                        "Outside Arbiters Grounds",
+                        "Arbiters Grounds Entrance",
+                        Zone.Arbiters_Grounds
+                    ),
+                    (
+                        "Snowpeak Summit Lower Left Door",
+                        "Snowpeak Ruins Left Door",
+                        Zone.Snowpeak_Ruins
+                    ),
+                    (
+                        "Sacred Grove Past Behind Window",
+                        "Temple of Time Entrance",
+                        Zone.Temple_of_Time
+                    ),
+                    ("Lake Hylia", "City in The Sky Entrance", Zone.City_in_the_Sky),
+                    (
+                        "Mirror Chamber Portal",
+                        "Palace of Twilight Entrance",
+                        Zone.Palace_of_Twilight
+                    ),
+                    (
+                        "Castle Town North Inside Barrier",
+                        "Hyrule Castle Entrance",
+                        Zone.Hyrule_Castle
+                    ),
+                };
+
+            // Build quick lookups
+            Dictionary<string, Zone> entranceToZone = new();
+            foreach ((string, string, Zone) tuple in exitToDungeonList)
+            {
+                entranceToZone[tuple.Item2] = tuple.Item3;
+            }
+
+            foreach ((string, string, Zone) tuple in exitToDungeonList)
+            {
+                string srcRoom = tuple.Item1;
+                string vanillaTargetRoom = tuple.Item2;
+                Zone entranceZone = tuple.Item3;
+
+                bool exitIsNotRandomized = false;
+                Entrance exitToMatch = null;
+
+                Room dungeonEntranceRoom = Randomizer.Rooms.RoomDict[srcRoom];
+                foreach (Entrance exit in dungeonEntranceRoom.Exits)
+                {
+                    if (exit.OriginalConnectedArea == vanillaTargetRoom)
+                    {
+                        exitToMatch = exit.GetReplacedEntrance();
+                        if (exitToMatch == null)
+                        {
+                            // If found the exit but it has no replacedEntrance,
+                            // then this one was not randomized and the dungeon
+                            // connection is vanilla.
+                            exitIsNotRandomized = true;
+                        }
+                        break;
+                    }
+                }
+
+                if (exitIsNotRandomized)
+                {
+                    result[entranceZone] = entranceZone;
+                }
+                else
+                {
+                    if (exitToMatch == null)
+                    {
+                        throw new Exception(
+                            $"Failed to find vanillaTargetRoom '{vanillaTargetRoom}'."
+                        );
+                    }
+
+                    string newTargetRoom = exitToMatch.OriginalConnectedArea;
+                    if (!entranceToZone.TryGetValue(newTargetRoom, out Zone targetDungeon))
+                        throw new Exception(
+                            $"Failed to find dungeon zone for entrance '{newTargetRoom}'."
+                        );
+
+                    result[entranceZone] = targetDungeon;
+                }
+            }
+
+            return result;
         }
 
         private Dictionary<AreaId, HashSet<Item>> prepareAreaIdToAllowBarrenItems()

--- a/Generator/Hints/HintSettings.cs
+++ b/Generator/Hints/HintSettings.cs
@@ -34,21 +34,20 @@ namespace TPRandomizer.Hints.Settings
             Dictionary<string, Func<HintGenData, bool>> conditionalAlways =
                 new()
                 {
-                    // {
-                    //     "Lake Hylia Shell Blade Grotto Chest",
-                    //     // Only hint when the poe next to the grotto is excluded
-                    //     // or vanilla
-                    //     (genData) => HintUtils.checkIsPlayerKnownStatus("Flight By Fowl Ledge Poe")
-                    // },
                     {
                         "Snowpeak Icy Summit Poe",
                         // Only hint when the poe is shuffled and there is no
                         // reason to go to SPR (unrequired is barren and SPR is
-                        // unrequired).
+                        // unrequired and unshuffled dungeon entrances so you
+                        // know that unrequired SPR is all that is behind the
+                        // doors).
                         (genData) =>
-                            !HintUtils.checkIsPlayerKnownStatus("Snowpeak Icy Summit Poe")
-                            && genData.sSettings.barrenDungeons
-                            && !HintUtils.getRequiredDungeonZones().Contains("Snowpeak Ruins")
+                        {
+                            return !HintUtils.checkIsPlayerKnownStatus("Snowpeak Icy Summit Poe")
+                                && genData.sSettings.barrenDungeons
+                                && genData.sSettings.shuffleDungeonEntrances == DungeonER.Off
+                                && !HintUtils.getRequiredDungeonZones().Contains("Snowpeak Ruins");
+                        }
                     },
                 };
             foreach (KeyValuePair<string, Func<HintGenData, bool>> pair in conditionalAlways)


### PR DESCRIPTION
- Snowpeak Mountain BeyondThisPoint hint now works with basic dungeon ER. Will create the hint only when the dungeon at the end of snowboarding is unrequiredBarren, even if it is changed from the vanilla SPR.
- Only create Always hint for Icy Summit Poe when dungeons are not randomized, meaning there is no reason to snowboard other than for this single poe (no reason to check the dungeon(s) located behind the SPR doors, and also no way to easily get there from decoupled entrances).
- Remove Clawshot from the base srcItems for ItemToItemPath hints. Clawshot unlocks way too many things to be helpful.