### PR TITLE
Fix bottles for minimal item scarcity; fix minor hint issue

### DIFF
--- a/Generator/Assets/Items.cs
+++ b/Generator/Assets/Items.cs
@@ -974,21 +974,34 @@ namespace TPRandomizer
                 // Include as few items as possible.
                 case ItemScarcity.Minimal:
                 {
-                    // Note we leave in the empty bottle since it shows up in
-                    // the `Faron Field.jsonc` file. It might be required in
-                    // Entrance Rando at some point, so leaving it in for now.
+                    // Note we leave in the empty bottle since it shows up in the `Faron
+                    // Field.jsonc` file. It might be required in Entrance Rando at some point, so
+                    // leaving it in for now.
+
+                    // Remove extra bottles
+                    updateItemToCount(RandomizedImportantItems, Item.Coro_Bottle, 0);
+                    updateItemToCount(RandomizedImportantItems, Item.Jovani_Bottle, 0);
+                    if (
+                        !parseSetting.bonksDoDamage
+                        || parseSetting.damageMagnification != DamageMagnification.OHKO
+                    )
+                    {
+                        // Only remove this bottle if OHKO bonks not turned on. Otherwise we need 2
+                        // bottles to be available for fairies for the Ordon Shield check.
+                        updateItemToCount(RandomizedImportantItems, Item.Sera_Bottle, 0);
+                    }
 
                     // Update alwaysItems
                     HashSet<Item> alwaysItemsToRemove =
                         new()
                         {
-                            Item.Heart_Container,
-                            Item.Piece_of_Heart,
-                            Item.Sera_Bottle,
-                            Item.Coro_Bottle,
-                            Item.Jovani_Bottle,
                             Item.Hawkeye,
                             Item.Giant_Bomb_Bag,
+                            // Note: the hearts are only filtered out when not required by HC
+                            // settings. If required, they are in RandomizedImportantItems and not
+                            // alwaysItems.
+                            Item.Heart_Container,
+                            Item.Piece_of_Heart,
                         };
 
                     // Filter out certain items

--- a/Generator/Hints/HintGenData.cs
+++ b/Generator/Hints/HintGenData.cs
@@ -475,7 +475,7 @@ namespace TPRandomizer.Hints
                     { Item.Arbiters_Grounds_Big_Key, 1 },
                     { Item.Arbiters_Grounds_Small_Key, 5 },
                     { Item.Snowpeak_Ruins_Bedroom_Key, 1 },
-                    { Item.Snowpeak_Ruins_Small_Key, 3 },
+                    { Item.Snowpeak_Ruins_Small_Key, 4 },
                     { Item.Snowpeak_Ruins_Ordon_Goat_Cheese, 1 },
                     { Item.Snowpeak_Ruins_Ordon_Pumpkin, 1 },
                     { Item.Temple_of_Time_Big_Key, 1 },


### PR DESCRIPTION
- Fix bottles not removed for Minimal item scarcity.
- Fix need min 2 bottles when OHKO bonks are enabled.
- Fix SPR small key count from 3 to 4 in some hint code.