### PR TITLE
Hide Wii name from UI for now

### DIFF
--- a/packages/client/getseed.html
+++ b/packages/client/getseed.html
@@ -356,6 +356,7 @@
             color: rgba(255, 255, 255, 0.9);
             padding-top: 8px;
             font-style: italic;
+            display: none;
           "
         ></div>
 


### PR DESCRIPTION
- Hide the Wii for now since it leads to confusion and is not relevant for 1.3