### PR TITLE
Fix two small logic bugs in and near Castle Town East

### DIFF
--- a/Generator/World/Checks/Overworld/Lanayru Province/East Castle Town Bridge Poe.jsonc
+++ b/Generator/World/Checks/Overworld/Lanayru Province/East Castle Town Bridge Poe.jsonc
@@ -1,5 +1,5 @@
 {
-    "requirements": "Shadow_Crystal and CanCompleteLanayruTwilight",
+    "requirements": "Shadow_Crystal",
     "glitchedRequirements": "Shadow_Crystal and CanCompleteLanayruTwilight",
     "checkCategory": ["Overworld", "Poe", "Hyrule Field - Lanayru Province"],
     "itemId": "Poe_Soul"

--- a/Generator/World/Rooms/Overworld/Lanayru Province/Castle Town.jsonc
+++ b/Generator/World/Rooms/Overworld/Lanayru Province/Castle Town.jsonc
@@ -255,8 +255,8 @@
       },
       {
         "ConnectedArea": "Outside Castle Town East",
-        "Requirements": "true",
-        "GlitchedRequirements": "true"
+        "Requirements": "CanCompleteLanayruTwilight",
+        "GlitchedRequirements": "CanCompleteLanayruTwilight"
       },
       {
         "ConnectedArea": "Castle Town South",


### PR DESCRIPTION
The door between Castle Town East and Outside Castle Town East is closed in Lanayru Twilight and the poe itself is not locked behind it.